### PR TITLE
Add Problem Matcher for TextLint

### DIFF
--- a/.github/matchers/textlint-unix.json
+++ b/.github/matchers/textlint-unix.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "textlint-unix",
+      "pattern": [
+        {
+          "regexp": "^.+(/content/.+):(\\d+):(\\d+): ([^\\]]+?) \\[([^/]+)/([^\\]]+)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "severity": 5,
+          "code": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,10 @@ jobs:
       - run: yarn install --frozen-lockfile
       - if: ${{ github.event_name == 'pull_request' }}
         run: yarn format
-      - run: yarn lint:text
+      # Add Problem Matcher so that TextLint results are surfaced.
+      # https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md
+      - run: echo "::add-matcher::.github/matchers/textlint-unix.json"
+      - run: yarn textlint --format unix './content/**/*.md'
       - run: yarn lint:format
       - if: ${{ github.event_name == 'pull_request' }}
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/content/docs/deploying.md
+++ b/content/docs/deploying.md
@@ -16,3 +16,5 @@ Gridsome generates static files when running the `gridsome build` command. By de
 Since these are simple HTML and JS files you only need a server which hosts these files.
 
 If you need more information on this topic, check out the [Gridsome Docs](https://gridsome.org/docs/deploy-to-netlify/) on this issue.
+
+Test TextLint catches CodeWars.


### PR DESCRIPTION
This should show the TextLint issues as annotations.

https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md

---

I might need to prevent TextLint from running when autoformat is done.