### PR TITLE
Update markdown reference

### DIFF
--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -19,7 +19,7 @@ You may find below a summary of the most used ones.
 
 ## Emphasis
 
-```code
+```markdown
 _This is italic_
 *This is also italic*
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -50,7 +50,7 @@ Use code spans and code blocks to show the text as is. Use code block to show th
 
 ### Code span
 
-Use single backtick (\`) to show the text as is inline.
+Use single backtick `` ` `` to show the text as is inline.
 
 ```markdown
 Code span example: `print("example")`
@@ -60,16 +60,37 @@ Code span example: `print("example")`
 
 For multiline code blocks, use triple backticks.
 
-Constraints:
-   - Put an empty line before and after the code block itself, so that it's rendered correctly
-   - The triple backticks must be alone one their line (see [extensions] for exceptions)
-
 ````markdown
 ```
 This is a code block
        you can indent inside it as you like.
 ```
 ````
+
+Note: The triple backticks must be alone one their line, otherwise the block will not be rendered correctly (see [extensions] for exceptions).
+
+````markdown
+```This is incorrect
+as a block
+```
+
+```
+Begins but,
+this is incorrect```
+````
+
+Sepcial case: languages blocks (see [extensions]):
+
+````markdown
+```python
+print("ab")    # this is code
+```
+
+```if:ruby
+This won't be rendered as code (see next documentation)
+```
+````
+
 
 
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -71,13 +71,6 @@ This is a code block
 ```
 ````
 
-Another way to declare a code block is to put 4 whitesapces at the beginning of the line
-
-````markdown
-   This will be rendered as a code block too
-           you can indent inside it as you like.
-
-````
 
 
 
@@ -116,7 +109,9 @@ Example:
 
 ## Links
 
-Valid url links are automatically converted to links. If you want to have a custom text instead of the url, you can you this syntax:
+Valid URLs are automatically converted to links with link text set to the URL.
+
+To specify a link text, use the following syntax:
 
 ```markdown
 [link text](https://www.example.com)

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -107,8 +107,8 @@ Example:
 
 Valid url links are automatically converted to links. If you want to have a custom text instead of the url, you can you this syntax:
 
-```code
-[Custom text](address)
+```markdown
+[link text](https://www.example.com)
 ```
 
 Like this [custom text leading to Codewars](https://www.codewars.com/dashboard).

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -10,6 +10,33 @@ Codewars supports [Markdown][wiki-markdown].
 
 More specifically, [GitHub Flavored Markdown][gfm] (strict superset of [CommonMark][common-mark]) and few [Codewars extensions][extensions].
 
+You may find below a summary of the most used ones.
+
+
+
+
+## Emphasis
+
+```code
+_This is italic_
+*This is also italic*
+
+__This is bold__
+**This is bold too**
+
+___here, italic and bold___
+***here, italic and bold***
+```
+Note that *You **can** combine them*: `*You **can** combine them*`.
+
+
+## Lists
+
+Unordered lists
+
+Ordered lists
+
+
 <!--
 TODO Finish this basic Markdown reference by listing most frequently used ones
 TODO Add tutorial for writing readable comment with Markdown

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -121,7 +121,7 @@ Like this [custom text leading to Codewars](https://www.codewars.com/dashboard).
 
 Similarly to links:
 
-```code
+```markdown
 ![alt text](address)
 ```
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -62,7 +62,7 @@ For multiline code blocks, use triple backticks.
 
 Constraints:
    - Put an empty line before and after the code block itself, so that it's rendered correctly
-   - The triple backticks must be alone one their line (see [extensions](./references/markdown/extensions/) for exceptions)
+   - The triple backticks must be alone one their line (see [extensions] for exceptions)
 
 ````markdown
 ```

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -85,7 +85,6 @@ You can use different marks to get same result, like `+` or `-`.
 
 ### Ordered lists:
 
-The numbering is automatic, hence you cannot mix different types of paragraphs or items if you want to keep the numbering correct.
 ```markdown
 1. item 1
 1. item 2

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -50,7 +50,7 @@ Use code spans and code blocks to show the text as is. Use code block to show th
 
 ### Code span
 
-Use single backtick `` ` `` to show the text as is inline.
+Use single backtick (\`) to show the text as is inline.
 
 ```markdown
 Code span example: `print("example")`

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -4,6 +4,8 @@ topic: markdown
 next: /references/markdown/extensions/
 ---
 
+
+
 # Basic Markdown Syntax
 
 Codewars supports [Markdown][wiki-markdown].
@@ -28,6 +30,19 @@ ___here, italic and bold___
 ***here, italic and bold***
 ```
 Note that `*You **can** combine them*`: *You **can** combine them*.
+
+
+
+
+## Headers
+
+```code
+# This is <h1>
+## This is <h2>
+###### This is <h6>
+```
+
+
 
 
 ## Lists
@@ -116,7 +131,7 @@ To quote the answer of another user, for example:
 > You quote like this...
 ```
 
-> ...and you get this...
+> ...and you get this.
 
 
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -36,23 +36,27 @@ Note that `*You **can** combine them*`: *You **can** combine them*.
 
 ## Headers
 
-```markdown
-# This is &lt;h1&gt;
-## This is &lt;h2&gt;
-###### This is &lt;h6&gt;
+```text
+# This is <h1>
+## This is <h2>
+### This is <h3>
 ```
 
 
 
-## Code blocks
+## Displaying code
 
-To get text displayed without the renderer playing with the indentation or whitespaces, code blocks
+Use code spans and code blocks to show the text as is. Use code block to show the syntax highlighted code.
 
-### Inline code blocks:
+### Code span
 
-To highlight code inside a sentence, use simple backticks  ``` `print("This is some code")` ```.
+Use single backtick (<code>`</code>) to show the text as is inline.
 
-### Mutliline code blocks:
+```markdown
+Code span example: `print("example")`
+```
+
+### Code block
 
 For multiline code blocks, use triple backticks.
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -50,7 +50,7 @@ Use code spans and code blocks to show the text as is. Use code block to show th
 
 ### Code span
 
-Use single backtick (`) to show the text as is inline.
+Use single backtick (\`) to show the text as is inline.
 
 ```markdown
 Code span example: `print("example")`

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -152,7 +152,7 @@ The related code is:
 
 To quote the answer of another user, for example:
 
-```code
+```markdown
 > Quoted text
 ```
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -74,7 +74,7 @@ Constraints:
 
 ### Unordered lists:
 
-```code
+```markdown
 * item 1
 * item 2
     * subitem 2.1

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -34,14 +34,6 @@ Note that `*You **can** combine them*`: *You **can** combine them*.
 
 
 
-## Headers
-
-<pre><code>
-# This is &lt;h1&gt;
-## This is &lt;h2&gt;
-### This is &lt;h3&gt;
-</code></pre>
-
 
 
 ## Displaying code

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -60,9 +60,9 @@ Constraints:
    - Put an empty line before and after the code block itself, so that it's rendered correctly
    - The triple backticks must be alone one their line (see [extensions](./references/markdown/extensions/) for exceptions)
 
-```code
+```markdown
 \`\`\`
-```
+\`\`\`
 ```
 
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -153,7 +153,7 @@ The related code is:
 To quote the answer of another user, for example:
 
 ```code
-> You quote like this...
+> Quoted text
 ```
 
 > Quoted text

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -37,9 +37,9 @@ Note that `*You **can** combine them*`: *You **can** combine them*.
 ## Headers
 
 ```code
-# This is <h1>
-## This is <h2>
-###### This is <h6>
+# This is &lt;h1&gt;
+## This is &lt;h2&gt;
+###### This is &lt;h6&gt;
 ```
 
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -28,8 +28,8 @@ __This is bold__
 
 ___here, italic and bold___
 ***here, italic and bold***
+*You can have **bold** in italic*
 ```
-Note that `*You **can** combine them*`: *You **can** combine them*.
 
 
 
@@ -50,16 +50,17 @@ Code span example: `print("example")`
 
 ### Code block
 
-For multiline code blocks, use triple backticks.
+For code blocks, use triple backticks (a "code fence").
 
 ````markdown
 ```
-This is a code block
-       you can indent inside it as you like.
+This is the content of the code block.
+       You can indent inside it as you like and it will be preserved.
 ```
 ````
 
-Info strings can be added on the opening triple backtick, to get the syntax highlighted. The info string must be a valid language name (`pyhton`, `javascript`, `php`, `ruby`, `cpp`, ...).
+The opening code fence can be followed by an optional text called the info string. When the info string is a valid language ID, `python` for example, the content is syntax highlighted.
+See the language's documentation in [supported languages](/languages/) to find the langauge ID.
 
 ````markdown
 ```python
@@ -71,7 +72,7 @@ def hello_world():
 ```
 ````
 
-See Codewars' [extensions] page about sequential and language specific blocks.
+If you're writing a kata description, see [Codewars' extensions][extensions] like sequential and language specific blocks.
 
 
 
@@ -89,25 +90,23 @@ See Codewars' [extensions] page about sequential and language specific blocks.
     * subitem 2.2
 ```
 
-You can use different marks to get same result, like `+` or `-`.
+You can use `-`, `*`, and `+` as bullet markers.
 
 ### Ordered lists
 
 ```markdown
 1. item 1
-1. item 2
-  * subitem 2.1
-  * subitem 2.2
-```
+    1. subitem 1.1
+2. item 2
+    * subitem 2.1
 
-Example:
+or
 
 1. item 1
-1. item 2
-    1. item 2.1
-    * unordered mark
-    1. cannot be item 2.2
-
+    1. subitem 1.1
+1. item 2 (incrementing the marker number is optional)
+    * subitem 2.1
+```
 
 
 ## Links
@@ -120,7 +119,6 @@ To specify a link text, use the following syntax:
 [link text](https://www.example.com)
 ```
 
-Like this [custom text leading to Codewars](https://www.codewars.com/dashboard).
 
 
 
@@ -128,7 +126,7 @@ Like this [custom text leading to Codewars](https://www.codewars.com/dashboard).
 
 ## Images
 
-Similarly to links:
+To include an image:
 
 ```markdown
 ![alt text](address)
@@ -144,7 +142,6 @@ To quote the answer of another user, for example:
 > Quoted text
 ```
 
-> Quoted text
 
 
 
@@ -152,7 +149,6 @@ To quote the answer of another user, for example:
 
 
 <!--
-TODO Finish this basic Markdown reference by listing most frequently used ones
 TODO Add tutorial for writing readable comment with Markdown
 TODO Add tutorial for formatting kata description
 -->

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -44,10 +44,18 @@ Note that `*You **can** combine them*`: *You **can** combine them*.
 
 
 
+## Code blocks
+
+To get text displayed without the renderer playing with the indentation or whitespaces, code blocks
+
+### Inline code blocks
+
+To highlight code  ` \`inline code block\` `
+
 
 ## Lists
 
-* Unordered lists:
+### Unordered lists:
 
 ```code
 * item 1
@@ -58,7 +66,7 @@ Note that `*You **can** combine them*`: *You **can** combine them*.
 
 You can use different marks to get same result, like `+` or `-`.
 
-* Ordered lists:
+### Ordered lists:
 
 The numbering is automatic, hence you cannot mix different types of paragraphs or items if you want to keep the numbering correct.
 ```code
@@ -74,7 +82,7 @@ Example:
 1. item 2
     1. item 2.1
     * unordered mark
-    1. cannot be itme 2.2
+    1. cannot be item 2.2
 
 
 
@@ -105,7 +113,7 @@ Similarly to links:
 ## Paragraphs & line continuations:
 
 * To get separated paragraphs, put an empty line between your paragraphs in the text.
-    If you just use a line break, both parapgraphs will be merged together when rendered, like those two lines even if they are written on two différent lines.
+    If you just use a line break, both parapgraphs will be merged together when rendered, like those two lines even if they are written on two different lines.
 
 * If you just want a line break without any space between the paragraphs, put two whitespaces  
     ...at the end of the line, like it is here.
@@ -113,8 +121,8 @@ Similarly to links:
 The related code is:
 
 ```code
-* To get separated paragraphs, put an empty line between your paragraphs in the text.
-    If you just use a line break, both parapgraphs will be merged together when rendered, like those two lines even if they are written on two différent lines.
+* To get separated [...] in the text.
+    If you just use [...] different lines.
 
 * If you just want a line break without any space between the paragraphs, put two whitespaces  
     ...at the end of the line, like it is here.

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -86,7 +86,7 @@ You can use different marks to get same result, like `+` or `-`.
 ### Ordered lists:
 
 The numbering is automatic, hence you cannot mix different types of paragraphs or items if you want to keep the numbering correct.
-```code
+```markdown
 1. item 1
 1. item 2
   * subitem 2.1

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -36,11 +36,11 @@ Note that `*You **can** combine them*`: *You **can** combine them*.
 
 ## Headers
 
-```text
-# This is <h1>
-## This is <h2>
-### This is <h3>
-```
+<pre><code>
+# This is &lt;h1&gt;
+## This is &lt;h2&gt;
+### This is &lt;h3&gt;
+</code></pre>
 
 
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -48,9 +48,26 @@ Note that `*You **can** combine them*`: *You **can** combine them*.
 
 To get text displayed without the renderer playing with the indentation or whitespaces, code blocks
 
-### Inline code blocks
+### Inline code blocks:
 
-To highlight code  ` \`inline code block\` `
+To highlight code inside a sentence, use simple backticks  ``` `print("This is some code")` ```.
+
+### Mutliline code blocks:
+
+For multiline code blocks, use triple backticks.
+
+Constraints:
+   - Put an empty line before and after the code block itself, so that it's rendered correctly
+   - The triple backticks must be alone one their line (see [extensions](./references/markdown/extensions/) for exceptions)
+
+```code
+\`\`\`
+```
+```
+
+
+
+
 
 
 ## Lists

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -50,7 +50,7 @@ Use code spans and code blocks to show the text as is. Use code block to show th
 
 ### Code span
 
-Use single backtick (<code>`</code>) to show the text as is inline.
+Use single backtick (`) to show the text as is inline.
 
 ```markdown
 Code span example: `print("example")`
@@ -84,7 +84,7 @@ Another way to declare a code block is to put 4 whitesapces at the beginning of 
 
 ## Lists
 
-### Unordered lists:
+### Unordered lists
 
 ```markdown
 * item 1
@@ -95,7 +95,7 @@ Another way to declare a code block is to put 4 whitesapces at the beginning of 
 
 You can use different marks to get same result, like `+` or `-`.
 
-### Ordered lists:
+### Ordered lists
 
 ```markdown
 1. item 1

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -138,27 +138,6 @@ Similarly to links:
 
 
 
-## Paragraphs & line continuations:
-
-* To get separated paragraphs, put an empty line between your paragraphs in the text.
-    If you just use a line break, both parapgraphs will be merged together when rendered, like those two lines even if they are written on two different lines.
-
-* If you just want a line break without any space between the paragraphs, put two whitespaces  
-    ...at the end of the line, like it is here.
-
-The related code is:
-
-```code
-* To get separated [...] in the text.
-    If you just use [...] different lines.
-
-* If you just want a line break without any space between the paragraphs, put two whitespaces  
-    ...at the end of the line, like it is here.
-```
-
-
-
-
 ## Blockquotes
 
 To quote the answer of another user, for example:

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -36,7 +36,7 @@ Note that `*You **can** combine them*`: *You **can** combine them*.
 
 ## Headers
 
-```code
+```markdown
 # This is &lt;h1&gt;
 ## This is &lt;h2&gt;
 ###### This is &lt;h6&gt;

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -27,14 +27,100 @@ __This is bold__
 ___here, italic and bold___
 ***here, italic and bold***
 ```
-Note that *You **can** combine them*: `*You **can** combine them*`.
+Note that `*You **can** combine them*`: *You **can** combine them*.
 
 
 ## Lists
 
-Unordered lists
+* Unordered lists:
 
-Ordered lists
+```code
+* item 1
+* item 2
+    * subitem 2.1
+    * subitem 2.2
+```
+
+You can use different marks to get same result, like `+` or `-`.
+
+* Ordered lists:
+
+The numbering is automatic, hence you cannot mix different types of paragraphs or items if you want to keep the numbering correct.
+```code
+1. item 1
+1. item 2
+  * subitem 2.1
+  * subitem 2.2
+```
+
+Example:
+
+1. item 1
+1. item 2
+    1. item 2.1
+    * unordered mark
+    1. cannot be itme 2.2
+
+
+
+## Links
+
+Valid url links are automatically converted to links. If you want to have a custom text instead of the url, you can you this syntax:
+
+```code
+[Custom text](address)
+```
+
+Like this [custom text leading to Codewars](https://www.codewars.com/dashboard).
+
+
+
+
+
+## Images
+
+Similarly to links:
+
+```code
+![alt text](address)
+```
+
+
+
+## Paragraphs & line continuations:
+
+* To get separated paragraphs, put an empty line between your paragraphs in the text.
+    If you just use a line break, both parapgraphs will be merged together when rendered, like those two lines even if they are written on two différent lines.
+
+* If you just want a line break without any space between the paragraphs, put two whitespaces  
+    ...at the end of the line, like it is here.
+
+The related code is:
+
+```code
+* To get separated paragraphs, put an empty line between your paragraphs in the text.
+    If you just use a line break, both parapgraphs will be merged together when rendered, like those two lines even if they are written on two différent lines.
+
+* If you just want a line break without any space between the paragraphs, put two whitespaces  
+    ...at the end of the line, like it is here.
+```
+
+
+
+
+## Blockquotes
+
+To quote the answer of another user, for example:
+
+```code
+> You quote like this...
+```
+
+> ...and you get this...
+
+
+
+
 
 
 <!--

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -156,7 +156,7 @@ To quote the answer of another user, for example:
 > You quote like this...
 ```
 
-> ...and you get this.
+> Quoted text
 
 
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -59,29 +59,19 @@ This is a code block
 ```
 ````
 
-Note: The triple backticks must be alone one their line, otherwise the block will not be rendered correctly (see [extensions] for exceptions).
-
-````markdown
-```This is incorrect
-as a block
-```
-
-```
-Begins but,
-this is incorrect```
-````
-
-Sepcial case: languages blocks (see [extensions]):
+Info strings can be added on the opening triple backtick, to get the syntax highlighted. The info string must be a valid language name (`pyhton`, `javascript`, `php`, `ruby`, `cpp`, ...).
 
 ````markdown
 ```python
-print("ab")    # this is code
-```
-
-```if:ruby
-This won't be rendered as code (see next documentation)
+def hello_world():
+    # this is rendered
+    hi = lambda: 'hello'
+    print(hi())
+    return 42 
 ```
 ````
+
+See Codewars' [extensions] page about sequential and language specific blocks.
 
 
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -60,12 +60,20 @@ Constraints:
    - Put an empty line before and after the code block itself, so that it's rendered correctly
    - The triple backticks must be alone one their line (see [extensions](./references/markdown/extensions/) for exceptions)
 
-```markdown
-\`\`\`
-\`\`\`
+````markdown
 ```
+This is a code block
+       you can indent inside it as you like.
+```
+````
 
+Another way to declare a code block is to put 4 whitesapces at the beginning of the line
 
+````markdown
+   This will be rendered as a code block too
+           you can indent inside it as you like.
+
+````
 
 
 

--- a/content/references/markdown/index.md
+++ b/content/references/markdown/index.md
@@ -97,16 +97,24 @@ You can use `-`, `*`, and `+` as bullet markers.
 ```markdown
 1. item 1
     1. subitem 1.1
+    2. subitem 1.2
 2. item 2
-    * subitem 2.1
+    * subitem (you can use unordered subitems too)
+3. item 3
+```
 
-or
+Incrementing the marker is optional so you can use the following too:
 
+```markdown
 1. item 1
     1. subitem 1.1
-1. item 2 (incrementing the marker number is optional)
-    * subitem 2.1
+    1. subitem 1.2
+1. item 2
+    * subitem (you can use unordered subitems too)
+1. item 3
 ```
+
+
 
 
 ## Links


### PR DESCRIPTION
* I feel like I've been too much verbose again, no? :/
* I didn't put the code blocks in there because of the `extensions` page. What should I do?
    - a section with a link to the extension page and put everything there?
    - or a section and talk about the simple code blocks (wwithout labels), then a link to the extensions?


Subsequent question: in the extensions page, there is the last section about math typesetting. Maybe it should be put into another page?