### PR TITLE
Change code span style

### DIFF
--- a/src/pages/Glossary.vue
+++ b/src/pages/Glossary.vue
@@ -22,7 +22,7 @@
           <!-- eslint-disable-next-line vue/no-v-html -->
           <div
             v-if="term.description"
-            class="prose ml-3"
+            class="prose max-w-none ml-3"
             v-html="term.description"
           />
 

--- a/src/pages/Languages.vue
+++ b/src/pages/Languages.vue
@@ -1,7 +1,7 @@
 <template>
   <Layout currentPath="/languages/" sidebar="docs">
     <div class="w-full md:w-2/3">
-      <div class="prose pt-8">
+      <div class="prose max-w-none pt-8">
         <h1 id="supported-languages">
           <a href="#supported-languages" aria-hidden="true"></a>
           Supported Languages

--- a/src/templates/Language.vue
+++ b/src/templates/Language.vue
@@ -26,7 +26,7 @@
         <!-- eslint-disable-next-line vue/no-v-html -->
         <div
           v-if="version.description"
-          class="prose"
+          class="prose max-w-none"
           v-html="version.description"
         />
       </div>

--- a/src/templates/MarkdownPage.vue
+++ b/src/templates/MarkdownPage.vue
@@ -9,7 +9,10 @@
 
       <div class="order-1 w-full md:w-2/3">
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <div class="prose pt-8" v-html="$page.markdownPage.content" />
+        <div
+          class="prose max-w-none pt-8"
+          v-html="$page.markdownPage.content"
+        />
 
         <div class="mt-8 pt-8 lg:mt-12 lg:pt-12 border-t border-ui-border">
           <NextPrevLinks :prev="prev" :next="next" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,16 +63,20 @@ module.exports = {
             // color: theme("colors.gray.600"),
             color: theme("colors.typo.low"),
           },
-          // Backticks can be removed by adding the following, but we should style it differently if we do.
-          // "code::before": {
-          //   content: "",
-          // },
-          // "code::after": {
-          //   content: "",
-          // },
+          "code::before": {
+            content: '""',
+          },
+          "code::after": {
+            content: '""',
+          },
           code: {
             // color: theme("colors.gray.900"),
             color: theme("colors.typo.high"),
+            borderColor: theme("colors.ui.border"),
+            borderWidth: "1px",
+            padding: theme("spacing.1"),
+            borderRadius: theme("borderRadius.default"),
+            fontWeight: null,
           },
           pre: {
             // color: theme("colors.gray.300"),


### PR DESCRIPTION
Surrounding code span with backticks can be annoying. Change to use the rounded border like the updated style on Codewars.