### PR TITLE
Use scroll-margin-top

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -50,20 +50,11 @@
   }
 }
 
-/* Required to show the heading below the fixed header on anchor navigation.
- * https://stackoverflow.com/a/38106970
+/* Prevent the sticky header from covering the element scrolled to.
+ * The margin should be greater than the height of the sticky header.
  */
-h1,
-h2,
-h3,
-h4,
-div,
-strong {
-  &[id]::before {
-    content: "";
-
-    @apply invisible block -mt-16 h-16;
-  }
+[id] {
+  scroll-margin-top: 4rem;
 }
 
 @tailwind utilities;

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,25 @@ export default function (Vue, { router, head, isClient }) {
   // Set default layout as a global component
   Vue.component("Layout", DefaultLayout);
 
+  // The default Gridsome behaviour with a fix to make `scroll-margin-top` work.
+  // https://github.com/gridsome/gridsome/issues/1361#issuecomment-709534494
+  router.options.scrollBehavior = async (to, from, saved) => {
+    if (saved) return saved;
+
+    if (to.hash) {
+      const elem = document.querySelector(to.hash);
+      if (elem) {
+        return {
+          selector: to.hash,
+          offset: { y: parseFloat(getComputedStyle(elem).scrollMarginTop) },
+        };
+      }
+      return { selector: to.hash };
+    }
+
+    return { x: 0, y: 0 };
+  };
+
   router.beforeEach((to, _from, next) => {
     head.meta.push({
       key: "og:url",


### PR DESCRIPTION
Fixes the following (note the first bullet point):
![image](https://user-images.githubusercontent.com/639336/98195940-c5c8b880-1ed7-11eb-892a-bdfb5291fd5b.png)

which is caused by a hack for preventing the sticky header covering the linked element. This hack was used instead of `scroll-margin-top` because I couldn't figure out why `scroll-margin-top` didn't work. This bug made me look into it further and found that it's caused by Vue router's `scrollBehavior` not configured to handle it.