### PR TITLE
Fix code span styling

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -64,19 +64,17 @@ module.exports = {
             color: theme("colors.typo.low"),
           },
           "code::before": {
-            content: '""',
+            content: "none",
           },
           "code::after": {
-            content: '""',
+            content: "none",
           },
           code: {
             // color: theme("colors.gray.900"),
             color: theme("colors.typo.high"),
             borderColor: theme("colors.ui.border"),
             borderWidth: "1px",
-            padding: "0 0.15em",
-            // Fix line break within padding
-            display: "inline-block",
+            padding: theme("spacing.1"),
             borderRadius: theme("borderRadius.default"),
             fontWeight: null,
           },


### PR DESCRIPTION
The weird break was caused by `code::before`/`code::after` that's used to remove the default backticks around code spans.

Fixes https://github.com/codewars/docs/issues/168