### PR TITLE
Authoring guidelines: Removed redundant notes

### DIFF
--- a/content/authoring/guidelines/preloaded.md
+++ b/content/authoring/guidelines/preloaded.md
@@ -11,11 +11,6 @@ The preloaded code snippet, created by the kata author or translator, can be use
 
 This article contains a set of guidelines for kata authors and translators to create good code snippets for their kata. They were collected to help ensure that kata and translations are of sufficient quality and kata maintenance will be as easy as possible.
 
-The guidelines should be used by kata authors, translators and reviewers to verify whether new content about to be introduced to Codewars is of sufficient quality. Conformance with them should be verified before a kata or translation is published by its author and approved by a reviewer.
-
-Failure to comply with the below guidelines should be considered an issue to be addressed and reported as such. In case of severe violations, the affected kata or translation may be retired, moved back to beta or rejected.
-
-
 ## Accessibility of Preloaded Code
 
 - The preloaded code snippet is code, and, as such, should conform to [Codewars General Coding Guidelines][authoring-guidelines-general].

--- a/content/authoring/guidelines/reference-solution.md
+++ b/content/authoring/guidelines/reference-solution.md
@@ -11,10 +11,6 @@ The reference solution snippet, created by the kata author or translator, has a 
 
 This article contains a set of guidelines for kata authors and translators to create good code snippets for their kata. They were collected to help ensure that kata and translations are of sufficient quality and kata maintenance will be as easy as possible.
 
-The guidelines should be used by kata authors, translators and reviewers to verify whether new content about to be introduced to Codewars is of sufficient quality. Conformance with them should be verified before a kata or translation is published by its author and approved by a reviewer.
-
-Failure to comply with the below guidelines should be considered an issue to be addressed and reported as such. In case of severe violations, the affected kata or translation may be retired, moved back to beta or rejected.
-
 ## General Guidelines
 
 - **Conform to [General Coding Guidelines][authoring-guidelines-general-coding]**{id="general"}: the reference solution is code too, and, as such, should keep up to code quality standards. It will make maintenance of the kata much easier, and the readability of the reference solution can be very helpful for future maintainers and translators. The reference solution is not for you to write, but for others to read.

--- a/content/authoring/guidelines/submission-tests.md
+++ b/content/authoring/guidelines/submission-tests.md
@@ -9,10 +9,6 @@ next: /authoring/guidelines/preloaded/
 
 This article contains a set of guidelines for kata authors or translators to create good test suites for their kata. They were collected to help ensure that kata, translations and their test suites are of sufficient quality so that users' experience with tests will be as good as possible.
 
-These guidelines should be used by kata authors, translators and reviewers to verify whether new content about to be introduced to Codewars is qualitative enough before they are published or approved.
-
-Failure to comply with the below guidelines should be considered an issue to be addressed and reported as such. In case of severe violations, the affected kata may be retired or moved back to beta, or the translation rejected.
-
 NOTE: There are many kinds of kata, and some guidelines might simply not apply to some of them (puzzles, hackmes, kata which mess with internals of the language runtime, and some types of challenges that require special ways of testing). But still, the present guidelines apply at least to some extent for the vast majority of kata, and if they are followed, kata authors can be sure that their tests will be clear, efficient, reliable, and easy to debug and maintain.
 
 

--- a/content/authoring/guidelines/translation.md
+++ b/content/authoring/guidelines/translation.md
@@ -8,10 +8,6 @@ prev: /authoring/guidelines/reference-solution/
 
 This article contains a set of guidelines, which can be used by translators to create good translations to existing kata. They were collected to help ensure that translations are of sufficient quality and users' experience will be as good as possible.
 
-The guidelines should be used by translators and reviewers to verify whether translations about to be introduced into Codewars are of sufficient quality. Conformance with them should be verified before the translation is published and before it's approved.
-
-Failure to comply with the below guidelines is considered an issue and should be reported as such. In case of severe violations, the affected translation can be rejected or even deleted.
-
 ## General translation guidelines
 
 - **Respect the [General Content Guidelines][authoring-guidelines-general].**


### PR DESCRIPTION
A note that content which does not conform to quality guidelines can be retired/rejected/removed has been added to "General" section. I think it's enough to have it in one general place rather than repeat it on every page.