### PR TITLE
Improve docs on Python testing framework

### DIFF
--- a/content/languages/python/authoring/index.md
+++ b/content/languages/python/authoring/index.md
@@ -75,6 +75,15 @@ When any of these imports are missing, then, for compatibility reasons, it will 
 
 If a user solution is expected to use functions or classes from the `preloaded` module, it's recommended to add required imports to the "initial solution" code snippet.
 
+:::note
+For simplicity, thorough the rest of this article it's assumed that `codewars_test` module is imported and aliased as `test` with following statement:
+
+```python
+import codewars_test as test
+```
+
+This is a convention used in many Python kata, but it's not a requirement, and authors can choose to import the module in any way they find suitable for them.
+:::
 
 ## Tests
 
@@ -82,10 +91,9 @@ If a user solution is expected to use functions or classes from the `preloaded` 
 
 Python kata use the [Codewars Python testing framework](/languages/python/codewars-test/) to implement and execute tests. You should read its reference page to find out how to use `describe` and `it` blocks for [organization and grouping](/languages/python/codewars-test/#organization-of-tests), what [assertions](/languages/python/codewars-test/#assertions-1) are available, etc.
 
-
 #### Dynamically generated test cases
 
-It's possible to put functions decorated with `it` in a loop and use them as a construct similar to parametrized test cases known from other testing frameworks, for example:
+It's possible to put functions decorated with `@test.it` in a loop and use them as a construct similar to parametrized test cases known from other testing frameworks, for example:
 
 ```python
 @test.describe("Generated test cases")
@@ -103,7 +111,7 @@ This technique is liked by authors familiar with testing frameworks that provide
 
 #### Decorated functions
 
-To create and present test output, the Python testing framework uses parameters of `describe` and `it` decorators, and ignores actual names of decorated functions. Since the names are often redundant with titles of `describe` or `it` sections, they can be replaced with some placeholder name, for example, `_`:
+To create and present test output, the Python testing framework uses parameters of `@test.describe` and `@test.it` decorators, and ignores actual names of decorated functions. Since the names are often redundant with titles of `describe` or `it` sections, they can be replaced with some placeholder name, for example, `_`:
 
 ```python
 @test.describe('Fixed tests')
@@ -170,7 +178,7 @@ The Python testing framework provides a set of useful [assertions](/languages/py
 
 To avoid the above problems, calls to assertion functions should respect the following rules:
 - The expected value should be calculated _before_ invoking an assertion. The `expected` parameter passed to the assertion should not be a function call expression, but a value calculated directly beforehand.
-- Appropriate assertion functions should be used for each given test. `assert_equals` is not suitable in all situations. Use `assert_approx_equals` for floating point comparisons, `expect` for tests on boolean values, `expect_error` to test error handling.
+- Appropriate assertion functions should be used for each given test. `test.assert_equals` is not suitable in all situations. Use `test.assert_approx_equals` for floating point comparisons, `test.expect` for tests on boolean values, `test.expect_error` to test error handling.
 - Some additional attention should be paid to the order of parameters passed to assertion functions. It differs between various assertion libraries, and it happens to be quite often confused by authors, mixing up `actual` and `expected` in assertion messages. For the Python testing framework, the order is `(actual, expected)`.
 - One somewhat distinctive feature of Python assertions is that by default, a failed assertion does not cause a test case to fail early. It can lead to unexpected crashes when an actual value had already been asserted to be invalid, but the execution of the current test case was not stopped and following assertions continue to refer to it. This behavior can be overridden by passing the `allow_raise=True` argument to the assertion functions that support it.
 - To avoid unexpected crashes in tests, it's recommended to perform some additional assertions before assuming that the answer returned by the user solution has some particular type, form, or value. For example, if the test suite sorts the returned list to verify its correctness, an explicit assertion should be added to check whether the returned object is actually a list, and not, for example, `None`.

--- a/content/languages/python/authoring/index.md
+++ b/content/languages/python/authoring/index.md
@@ -80,7 +80,7 @@ If a user solution is expected to use functions or classes from the `preloaded` 
 
 ### Testing framework
 
-Python kata use the [Codewars Python testing framework](/languages/python/codewars-test/) to implement and execute tests. You should read its reference page to find out how to use `describe` and `it` blocks for [organization and grouping](/languages/python/codewars-test/#grouping-tests), what [assertions](/languages/python/codewars-test/#assertions) are available, etc.
+Python kata use the [Codewars Python testing framework](/languages/python/codewars-test/) to implement and execute tests. You should read its reference page to find out how to use `describe` and `it` blocks for [organization and grouping](/languages/python/codewars-test/#organization-of-tests), what [assertions](/languages/python/codewars-test/#assertions-1) are available, etc.
 
 
 #### Dynamically generated test cases
@@ -163,7 +163,7 @@ The reference solution or data ___must not___ be defined in the top-level scope 
 
 ### Calling assertions
 
-The Python testing framework provides a set of useful [assertions](/languages/python/codewars-test/#assertions), but when used incorrectly, they can cause a series of problems:
+The Python testing framework provides a set of useful [assertions](/languages/python/codewars-test/#assertions-1), but when used incorrectly, they can cause a series of problems:
 - Stacktraces of a crashing user solution can reveal details that should not be visible,
 - Use of an assertion not suitable for the given case may lead to incorrect test results,
 - Incorrectly used assertions may produce confusing or unhelpful messages.

--- a/content/languages/python/authoring/index.md
+++ b/content/languages/python/authoring/index.md
@@ -2,6 +2,7 @@
 kind: tutorial
 languages: [python]
 sidebar: "language:python"
+prev: /languages/python/codewars-test/
 ---
 
 # Python: creating and translating a kata

--- a/content/languages/python/authoring/index.md
+++ b/content/languages/python/authoring/index.md
@@ -76,7 +76,7 @@ When any of these imports are missing, then, for compatibility reasons, it will 
 If a user solution is expected to use functions or classes from the `preloaded` module, it's recommended to add required imports to the "initial solution" code snippet.
 
 :::note
-For simplicity, thorough the rest of this article it's assumed that `codewars_test` module is imported and aliased as `test` with following statement:
+For simplicity, through the rest of this article it's assumed that the `codewars_test` module is imported and aliased as `test` with the following statement:
 
 ```python
 import codewars_test as test

--- a/content/languages/python/codewars-test/index.md
+++ b/content/languages/python/codewars-test/index.md
@@ -5,6 +5,7 @@ tags:
   - testing
 sidebar: "language:python"
 prev: /languages/python/
+next: /languages/python/authoring/
 ---
 
 # Python Codewars Test Framework

--- a/content/languages/python/codewars-test/index.md
+++ b/content/languages/python/codewars-test/index.md
@@ -24,19 +24,19 @@ Additionally, the framework provides a set of functions performing assertions on
 All functions, decorators, and assertions provided by the framework are defined in `codewars_test` Python module.
 
 :::warning Deprecation
-Python runner for verions prior to Python 3.8 does not contain the `codewars_test` module. The testing framework is imported implicitly and aliased as `test` and `Test`. This behavior is deprecated and for the Python 3.8 kata the explicit import is required.
+The Python runner for versions prior to Python 3.8 does not contain the `codewars_test` module. The testing framework is imported implicitly and aliased as `test` and `Test`. This behavior is deprecated and for the Python 3.8 kata, the explicit import is required.
 :::
 
 ## Organization of tests
 
-Tests in Python testing framework are composed from functions decorated with a set of Python decorators. All such functions are automatically discovered and run. The final result for every test block is determined by contained assertions, and reported along with its measured execution time.
+Tests in the Python testing framework are composed of functions decorated with a set of Python decorators. All such functions are automatically discovered and run. The final result for every test block is determined by contained assertions and reported along with its measured execution time.
 
 
 ### Test groups: `@describe`
 
 Functions decorated with `@describe` represent a group of logically related test cases.
 
-`@describe` functions can contain another, nested test groups (functions decorated with `@describe`), or individual test cases (functions decorated with `@it`, see below).
+`@describe` functions can contain more nested test groups (functions decorated with `@describe`) or individual test cases (functions decorated with `@it`, see below).
 
 Test groups cannot contain assertions.
 
@@ -45,14 +45,14 @@ Test groups cannot contain assertions.
 
 Functions decorated with `@it` represent a single test case. They can be defined inside of a function decorated with `@describe`, or can be top level functions.
 
-`@it` functions can contain only assertions, and cannot nest another test cases nor test groups.
+`@it` functions can contain only assertions, and cannot nest other test cases or test groups.
 
 
 ### Assertions
 
 Assertions can be located only inside of a test case (a function decorated with `@it`). They must not be located directly under a test group (a function decorated with `@describe`), or in the top level of test.
 
-Every assertion generates separate log entry in the test output.
+Every assertion generates a separate log entry in the test output.
 
 Note that failed assertions do not stop the execution of the enclosing test case by default. See [Failing Early](#failing-early) on how to control this behavior.
 
@@ -102,7 +102,7 @@ The above produces an output similar to the following:
 
 ## Failing Early
 
-Most of assertion functions can accept a named argument `allow_raise=False`.
+Most assertion functions can accept a named argument `allow_raise=False`.
 
 If you change its value to `True`, the tests contained inside the current block will be interrupted at the first failed test. The execution goes back to the parent block if it exists and the next part is executed.
 
@@ -138,7 +138,7 @@ Default message is _"\<actual\> should not equal \<expected\>"_.
 test.assert_approx_equals(actual, expected, margin=1e-9, message=None, allow_raise=False)
 ```
 
-Checks if the actual value is close enough to the expected one, with a default relative or absolute value of `margin`. The comparison is performed in following way:
+Checks if the actual value is close enough to the expected one, with a default relative or absolute value of `margin`. The comparison is performed like this:
 
 ```python
 div = max(abs(actual), abs(expected), 1)
@@ -181,7 +181,7 @@ test.expect_error(message, function, exception=Exception)
 
 Checks whether invoked `function` throws an exception. Raised exception must be an instance of a type specified with `exception` argument.
 
-The `exception` argument can specify a single type or a tuple of multiple exception types. Assertion is satisfied when the raised exception is an instance of at least one of specified types.
+The `exception` argument can specify a single type or a tuple of multiple exception types. The assertion is satisfied when the raised exception is an instance of at least one of the specified types.
 
 #### Example
 
@@ -202,7 +202,7 @@ test.expect_no_error(message, function, exception=BaseException)
 
 Checks whether invoked `function` does not throw an exception of a type specified by `exception`.
 
-The `exception` argument can specify a single type or a tuple of multiple exception types. Assertion is satisfied when no exception is raised, or when the raised exception is _not_ an instance of at least one of specified types. If during the execution of `function` an exception is raised that does _not_ match the parameter `exception`, it is silenced and the test is considered passed.
+The `exception` argument can specify a single type or tuple of multiple exception types. The assertion is satisfied when no exception is raised, or when the raised exception is _not_ an instance of at least one of specified types. If during the execution of `function` an exception is raised that does _not_ match the parameter `exception`, it is silenced and the test is considered passed.
 
 #### Example
 
@@ -221,10 +221,10 @@ Runs the decorated function within the time limit.
 `sec` is the amount of time allowed. It is expressed in seconds and can be given as an integer or float.  
 Generates a failed assertion when the function fails to complete in time, and its execution is terminated immediately.
 
-Decorated function is required to not throw any exception. If an error is raised during its execution, the test is considered failed and the error message becomes _"Should not throw any exceptions inside timeout: \<Exception()\>"_. This requirement is enforced by wrapping the inner function with `expect_no_error`, and as a side effect, one extra "test passed" entry is emitted for a collection of tests run inside a timeout wrapper.
+The decorated function is required to not throw any exceptions. If an error is raised during its execution, the test is considered failed and the error message becomes _"Should not throw any exceptions inside timeout: \<Exception()\>"_. This requirement is enforced by wrapping the inner function with `expect_no_error`, and as a side effect, one extra "test passed" entry is emitted for a collection of tests run inside a timeout wrapper.
 
 :::warning
-Timed test should contain at least one assertion which verifies the result returned by the user solution. Otherwise, the test will be considered passed just if it happens to finish in time below the requested time limit, even if it would return incorrect answer.
+Timed tests should contain at least one assertion which verifies the result returned by the user solution. Otherwise, the test will be considered passed just if it happens to finish in time below the requested time limit, even if it would return an incorrect answer.
 :::
 
 ### Example

--- a/content/languages/python/codewars-test/index.md
+++ b/content/languages/python/codewars-test/index.md
@@ -118,7 +118,7 @@ Checks that the actual value equals the expected value.
 
 Note that because Python's equality operator checks for deep equality by default, you don't have to compare the contents of the array element by element yourself when you want to compare values as lists, tuples, sets, etc.
 
-Default message is _"<actual> should equal <expected>"_.
+Default message is _"\<actual\> should equal \<expected\>"_.
 
 This function is usually the main building block of a Kata's test cases.
 
@@ -129,7 +129,7 @@ test.assert_not_equals(actual, expected, message=None, allow_raise=False)
 ```
 
 Checks that the actual value does not equal the (un)expected value.
-Default message is _"<actual> should not equal <expected>"_.
+Default message is _"\<actual\> should not equal \<expected\>"_.
 
 ### Approximate equality tests
 
@@ -146,12 +146,12 @@ is_good = abs((actual - expected) / div) < margin
 
 So you can compare either big or small floating-point values without problems.
 
-Default message is _"<actual> should be close to <expected> with absolute or relative margin of <margin>"_.
+Default message is _"\<actual\> should be close to \<expected\> with absolute or relative margin of \<margin\>"_.
 
 ### Truthness tests
 
 ```python
-test.expect(expected, message=None)
+test.expect(passed=None, message=None, allow_raise=False)
 ```
 
 Checks if the passed value is truthy. This function can be helpful when you test something which cannot be tested using other assertion functions.  

--- a/content/languages/python/codewars-test/index.md
+++ b/content/languages/python/codewars-test/index.md
@@ -216,14 +216,6 @@ test.expect_no_error(msg, f, OSError)          # Pass
 
 ## Timeout Utility
 
-```python
-@test.timeout(sec)                      # default message: Exceeded time limit of <sec> seconds
-def some_function():
-    #do some heavy tests here...
-    for _ in ad_nauseam():
-        test.assert_equals(count_atoms_in_universe(), expected)
-```
-
 Runs the decorated function within the time limit.  
 
 `sec` is the amount of time allowed. It is expressed in seconds and can be given as an integer or float.  
@@ -234,6 +226,16 @@ Decorated function is required to not throw any exception. If an error is raised
 :::warning
 Timed test should contain at least one assertion which verifies the result returned by the user solution. Otherwise, the test will be considered passed just if it happens to finish in time below the requested time limit, even if it would return incorrect answer.
 :::
+
+### Example
+
+```python
+@test.timeout(sec)                      # default message: Exceeded time limit of <sec> seconds
+def some_function():
+    #do some heavy tests here...
+    for _ in ad_nauseam():
+        test.assert_equals(count_atoms_in_universe(), expected)
+```
 
 ## Acknowledgements
 

--- a/content/languages/python/codewars-test/index.md
+++ b/content/languages/python/codewars-test/index.md
@@ -28,7 +28,7 @@ The Python runner for versions prior to Python 3.8 does not contain the `codewar
 :::
 
 :::note
-For simplicity, thorough the rest of this article it's assumed that `codewars_test` module is imported and aliased as `test` with following statement:
+For simplicity, through the rest of this article it's assumed that the `codewars_test` module is imported and aliased as `test` with the following statement:
 
 ```python
 import codewars_test as test

--- a/content/languages/python/codewars-test/index.md
+++ b/content/languages/python/codewars-test/index.md
@@ -27,30 +27,40 @@ All functions, decorators, and assertions provided by the framework are defined 
 The Python runner for versions prior to Python 3.8 does not contain the `codewars_test` module. The testing framework is imported implicitly and aliased as `test` and `Test`. This behavior is deprecated and for the Python 3.8 kata, the explicit import is required.
 :::
 
+:::note
+For simplicity, thorough the rest of this article it's assumed that `codewars_test` module is imported and aliased as `test` with following statement:
+
+```python
+import codewars_test as test
+```
+
+This is a convention used in many Python kata, but it's not a requirement, and authors can choose to import the module in any way they find suitable for them.
+:::
+
 ## Organization of tests
 
 Tests in the Python testing framework are composed of functions decorated with a set of Python decorators. All such functions are automatically discovered and run. The final result for every test block is determined by contained assertions and reported along with its measured execution time.
 
 
-### Test groups: `@describe`
+### Test groups: `@test.describe`
 
-Functions decorated with `@describe` represent a group of logically related test cases.
+Functions decorated with `@test.describe` represent a group of logically related test cases.
 
-`@describe` functions can contain more nested test groups (functions decorated with `@describe`) or individual test cases (functions decorated with `@it`, see below).
+`@test.describe` functions can contain more nested test groups (functions decorated with `@test.describe`) or individual test cases (functions decorated with `@test.it`, see below).
 
 Test groups cannot contain assertions.
 
 
-### Test cases: `@it`
+### Test cases: `@test.it`
 
-Functions decorated with `@it` represent a single test case. They can be defined inside of a function decorated with `@describe`, or can be top level functions.
+Functions decorated with `@test.it` represent a single test case. They can be defined inside of a function decorated with `@test.describe`, or can be top level functions.
 
-`@it` functions can contain only assertions, and cannot nest other test cases or test groups.
+`@test.it` functions can contain only assertions, and cannot nest other test cases or test groups.
 
 
 ### Assertions
 
-Assertions can be located only inside of a test case (a function decorated with `@it`). They must not be located directly under a test group (a function decorated with `@describe`), or in the top level of test.
+Assertions can be located only inside of a test case (a function decorated with `@test.it`). They must not be located directly under a test group (a function decorated with `@test.describe`), or in the top level of test.
 
 Every assertion generates a separate log entry in the test output.
 
@@ -216,7 +226,7 @@ test.expect_no_error(msg, f, OSError)          # Pass
 
 ## Timeout Utility
 
-Runs the decorated function within the time limit.  
+Runs a function decorated with `@test.timeout` within the time limit.  
 
 `sec` is the amount of time allowed. It is expressed in seconds and can be given as an integer or float.  
 Generates a failed assertion when the function fails to complete in time, and its execution is terminated immediately.


### PR DESCRIPTION
Discussion: #197 
Deploy preview: [here](https://deploy-preview-198--reverent-edison-2864ea.netlify.app/languages/python/codewars-test/)

I wanted to remove parts which became redundant after introducing "Authoring Python kata" doc, and to make it look more like an actual reference rather than a HOWTO. I hope I did not remove too much, but if you think something is missing, let me know.
