### PR TITLE
Fix markdown formatting of a code block

### DIFF
--- a/content/languages/cpp/igloo/stringizers.md
+++ b/content/languages/cpp/igloo/stringizers.md
@@ -62,6 +62,7 @@ It(does_not_pretty_print_type_without_stringizer)
 ```
 
 Test output:
+
 ```
   does_not_pretty_print_vector_of_type_without_stringizer
     Expected: equal to [ [unsupported type], [unsupported type] ]


### PR DESCRIPTION
Missing blank line causes one code block to render incorrectly.