### PR TITLE
Add Docs to navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,16 +31,12 @@ module.exports = {
         href: "https://www.codewars.com/",
       },
       items: [
-        // {
-        //   label: "Languages",
-        //   position: "left",
-        //   items: [
-        //     {
-        //       label: "JavaScript",
-        //       href: "/languages/javascript",
-        //     },
-        //   ],
-        // },
+        {
+          label: "Docs",
+          activeBaseRegex: "/(?!search)",
+          position: "left",
+          to: "/",
+        },
         {
           href: "https://github.com/codewars",
           position: "right",


### PR DESCRIPTION
This is necessary because the search page doesn't have the sidebar, and we have the link brand link to codewars.com.