### PR TITLE
Added documentation for Factor

### DIFF
--- a/content/languages/factor/authoring.md
+++ b/content/languages/factor/authoring.md
@@ -83,44 +83,46 @@ To create and present test output, testest uses the `describe#{` and `it#{` word
 ```factor
 "Fixed tests" describe#{
   "Odd numbers" it#{
-    ! some assertions...
+    ! some tests...
   }#
 
   "Even numbers" it#{
-    ! some assertions...
+    ! some tests...
   }#
 }#
 
 "Random tests" describe#{
   "Small inputs" it#{
-    ! some assertions...
+    ! some tests...
   }#
 
   "Large inputs" it#{
-    ! some assertions...
+    ! some tests...
   }#
 }#
 ```
 
-`describe` blocks can contain `describe` or `it` blocks, but `it` blocks can only contain assertions.
+`describe` blocks can contain `describe` or `it` blocks, but `it` blocks can only contain unit tests.
 
-#### Assertions
+#### Unit tests
 
-Assertions with testest are created using the following syntax:
+Unit tests with testest are created using the following syntax:
 ```factor
 <{ ...inputs -> ...expected }>
 ```
-The left side `...inputs` including whatever setup you wish to test, and the right side `...expected` being what the resulting stack should be. For example:
+The left side `...inputs` should include whatever setup you wish to test, and the right side `...expected` should include what the resulting stack should be. For example:
 
 ```factor
 <{ 3 4 add -> 7 }>
 ```
 
-Note that `...inputs` is not limited to just literals and the tested word. For example a word with the stack effect `( ... a b -- ... r )` might need to be tested with leading values, to ensure they are not changed:
+:::note
+The values in unit tests are not limited to just literals and the tested word. For example a word with the stack effect `( ... a b -- ... r )` might need to be tested with leading values, to ensure they are not changed:
 
 ```factor
 <{ t "str" 3 4 special-add -> t "str" 7 }>
 ```
+:::
 
 ### Generating random values
 
@@ -160,11 +162,11 @@ IN: multiply.tests
 MAIN: run-tests
 ```
 
-### Custom assertion messages
+### Custom result messages
 
-Sometimes it can be helpful to have full control over the assertion messages for both passing and failing assertions. `testest` includes the ability to set custom messages, as well as a couple helper words:
-- `lf` will simply output `"<:LF:>"`, which is required by Codewars to properly print a new-line in assertion messages
-- `seq.` will properly print a sequence, in particular to be used for `expected` and `got` in failure assertions.
+Sometimes it can be helpful to have full control over the unit test messages for both passing and failing tests. `testest` includes the ability to set custom messages, as well as a couple helper words:
+- `lf` will simply output `"<:LF:>"`, which is required by Codewars to properly print a new-line in success and failure messages
+- `seq.` will properly print a sequence, in particular to be used for `expected` and `got` in failure messages.
 
 **Success**
 
@@ -175,7 +177,7 @@ Custom success messages can be set by assigning a quotation with stack effect `(
 
 **Failure**
 
-Similarly to success messages, custom failure messages can be set by assigning a quotation to the variable `test-failed.`. This quotation must have the stack effect `( assert-sequence -- )` where `assert-sequence` is a tuple with slots `got` and `expected`, each containing sequences of the relevant elements in the assertion.
+Similarly to success messages, custom failure messages can be set by assigning a quotation to the variable `test-failed.`. This quotation must have the stack effect `( assert-sequence -- )` where `assert-sequence` is a tuple with slots `got` and `expected`, each containing sequences of the relevant elements in the unit test.
 
 A simple failure message might look something like this:
 ```factor
@@ -189,8 +191,15 @@ or a more informative failure message might look like this:
   bi
 ] test-failed. set
 ```
+Sometimes it might be helpful to include additional values in the unit-test, so that they are available to your custom quotation, in the case of failure.
+```factor
+[ expected>> first2 number>string write " IS" " is NOT" ? write " divisible by 7" write ] test-failed. set
+100 random :> i
+<{ i >bin re matches? i -> i 7 multiple? i }> ! Extra i on both sides, for use by failure message
+```
+
 :::note
-When a custom success or failure message is set, the new message will be displayed for all future assertions until changed again.
+When a custom success or failure message is set, the new message will be displayed for all future unit tests until changed again.
 
 If you want to set a custom message for only a limited number of tests, you can use [`with-scope`](https://docs.factorcode.org/content/word-with-scope,namespaces.html) to revert all variables once the scope ends.
 :::

--- a/content/languages/factor/authoring.md
+++ b/content/languages/factor/authoring.md
@@ -42,7 +42,7 @@ Factor-specific paragraphs can be inserted with [language conditional rendering]
 
 ## Tasks and Requirements
 
-Some concepts don't always translate well to or from Factor. Because of this some constructs should be avoided and some translations just shouldn't be done.
+Some concepts don't always translate well to or from Factor. Because of this some constructs should be avoided, and some translations just shouldn't be done.
 - Factor has explicit stack effects, which means some Kata involving multi-variadic functions (among other things) might be difficult to translate properly.
 
 Some kata just should not be translated into Factor because it can be difficult to keep their initial idea:

--- a/content/languages/factor/authoring.md
+++ b/content/languages/factor/authoring.md
@@ -160,6 +160,41 @@ IN: multiply.tests
 MAIN: run-tests
 ```
 
+### Custom assertion messages
+
+Sometimes it can be helpful to have full control over the assertion messages for both passing and failing assertions. `testest` includes the ability to set custom messages, as well as a couple helper words:
+- `lf` will simply output `"<:LF:>"`, which is required by Codewars to properly print a new-line in assertion messages
+- `seq.` will properly print a sequence, in particular to be used for `expected` and `got` in failure assertions.
+
+**Success**
+
+Custom success messages can be set by assigning a quotation with stack effect `( -- )` to the variable `test-passed.`. For example, using [`write`](https://docs.factorcode.org/content/word-write,io.html) and [`set`](https://docs.factorcode.org/content/word-set,namespaces.html) as follows:
+```factor
+[ "Custom message" write ] test-passed. set
+```
+
+**Failure**
+
+Similarly to success messages, custom failure messages can be set by assigning a quotation to the variable `test-failed.`. This quotation must have the stack effect `( assert-sequence -- )` where `assert-sequence` is a tuple with slots `got` and `expected`, each containing sequences of the relevant elements in the assertion.
+
+A simple failure message might look something like this:
+```factor
+[ "Good try, but no." write drop ] test-failed. set
+```
+or a more informative failure message might look like this:
+```factor
+[
+  [ "The result should have been: " write expected>> seq. ]
+  [ lf "but instead it was: " write got>> seq. ]
+  bi
+] test-failed. set
+```
+:::note
+When a custom success or failure message is set, the new message will be displayed for all future assertions until changed again.
+
+If you want to set a custom message for only a limited number of tests, you can use [`with-scope`](https://docs.factorcode.org/content/word-with-scope,namespaces.html) to revert all variables once the scope ends.
+:::
+
 ### Parsing word limitations
 
 Kata which involve defining parsing words can run into some problems when writing tests. Here are listed some known problems, as well as potential workarounds.

--- a/content/languages/factor/authoring.md
+++ b/content/languages/factor/authoring.md
@@ -115,6 +115,7 @@ The left side `...inputs` should include whatever setup you wish to test, and th
 ```factor
 <{ 3 4 add -> 7 }>
 ```
+The unit test is passed or failed depending on if the resulting stacks match. The test result message can be [fully customized](/languages/factor/authoring#custom-result-messages).
 
 :::note
 The values in unit tests are not limited to just literals and the tested word. For example a word with the stack effect `( ... a b -- ... r )` might need to be tested with leading values, to ensure they are not changed:

--- a/content/languages/factor/authoring.md
+++ b/content/languages/factor/authoring.md
@@ -133,7 +133,7 @@ The `random` [vocabulary](https://docs.factorcode.org/content/vocab-random.html)
 
 ### Recipe: Generating random tests
 
-The following words can useful in writing concise and understand random tests:
+The following words can be useful in writing concise and understandable random tests:
 - Binding lexical variables with [`:>`](https://docs.factorcode.org/content/word-__colon____gt__,syntax.html) makes it much easier to use randomly generated values in multiple places.
 - Test group labels can be formatted with [`vsprintf`](https://docs.factorcode.org/content/word-vsprintf,formatting.html) to include inputs (where appropriate)
 - Tests can be run in a loop using [`times`](https://docs.factorcode.org/content/word-times,math.html).

--- a/content/languages/factor/authoring.md
+++ b/content/languages/factor/authoring.md
@@ -1,0 +1,237 @@
+---
+title: Authoring Factor Content
+sidebar_label: Authoring
+---
+
+This article is intended for kata authors and translators who would like to create new content in Factor. It attempts to explain how to create and organize things in a way conforming to [authoring guidelines](/authoring/guidelines/), shows the most common pitfalls and how to avoid them.
+
+This article is not a standalone tutorial on creating kata or translations. It's meant to be a complementary, Factor-specific part of a more general set of HOWTOs and guidelines related to [content authoring](/authoring/). If you are going to create a Factor translation, or a new Factor kata from scratch, please make yourself familiar with the aforementioned documents related to authoring in general first.
+
+
+## General info
+
+Any technical information related to the Factor setup on Codewars can be found on the [Factor reference](/languages/factor/) page (language versions, available libraries, and setup of the code runner).
+
+## Description
+
+Factor code blocks can be inserted with Factor-specific part in [sequential code blocks](/references/markdown/extensions/#sequential-code-blocks):
+
+~~~
+```factor
+
+...your code here...
+
+```
+~~~
+
+Factor-specific paragraphs can be inserted with [language conditional rendering](/references/markdown/extensions/#conditional-rendering):
+
+```
+~~~if:factor
+
+...text visible only for Factor description...
+
+~~~
+
+~~~if-not:factor
+
+...text not visible in Factor description...
+
+~~~
+```
+
+## Tasks and Requirements
+
+Some concepts don't always translate well to or from Factor. Because of this, some constructs should be avoided and some translations just shouldn't be done.
+- Factor has explicit stack effects, which means some Kata involving multi-variadic functions (among other things) might be difficult to translate properly.
+
+Some kata just should not be translated into Factor because it can be difficult to keep their initial idea:
+- Some kata might be meant for another language specifically. For example, a kata about `Python: Learning Classes` should probably not be translated to Factor.
+- Factor also includes a very extensive range of available words and functionalities. This might mean that some Kata might be far easier to solve in Factor than in other languages. For example, `Efficient Power Modulo n` is a `5 kyu` kata that could be solved with a single word in Factor (`^mod`). Any kata that is significantly easier in Factor than in existing languages, should probably not be translated.
+
+## Tests
+
+### testest
+
+Factor kata should use [testest](/languages/factor/testest/) to implement and execute tests.
+
+#### Setup
+
+A standard header should be included as a part of the initial solution, including a `USING:` line, and an `IN:` line with a predefined vocabulary name.
+
+```factor
+USING: kernel ;
+IN: add-three
+```
+
+Similarly, both Sample tests and Submission tests require these lines, and should each import:
+- the solution vocabulary
+- the testest vocabulary (`tools.testest`)
+- any other vocabularies required by your tests (eg. `random`)
+
+The vocabulary name of each should be the same as the solution vocabulary, with an additional `.tests` suffix.
+
+```factor
+USING: add-three tools.testest kernel math ;
+IN: add-three.tests
+```
+
+#### Test grouping functions
+
+To create and present test output, testest uses the `describe#{` and `it#{` words:
+
+```factor
+"Fixed tests" describe#{
+  "Odd numbers" it#{
+    ! some assertions...
+  }#
+
+  "Even numbers" it#{
+    ! some assertions...
+  }#
+}#
+
+"Random tests" describe#{
+  "Small inputs" it#{
+    ! some assertions...
+  }#
+
+  "Large inputs" it#{
+    ! some assertions...
+  }#
+}#
+```
+
+`describe` blocks can contain `describe` or `it` blocks, but `it` blocks can only contain assertions.
+
+#### Assertions
+
+Assertions with testest are created using the following syntax:
+```factor
+<{ ...inputs -> ...expected }>
+```
+The left side `...inputs` including whatever setup you wish to test, and the right side `...expected` being what the resulting stack should be. For example:
+
+```factor
+<{ 3 4 add -> 7 }>
+```
+
+Note that `...inputs` is not limited to just literals and the tested word. For example a word with the stack effect `( ... a b -- ... r )` might need to be tested with leading values, to ensure they are not changed:
+
+```factor
+<{ t "str" 3 4 special-add -> t "str" 7 }>
+```
+
+### Generating random values
+
+The `random` [vocabulary](https://docs.factorcode.org/content/vocab-random.html) provided by Factor has multiple words which are helpful for generating random tests. In particular, is the generic word `random` itself, which serves multiple functions:
+
+```factor
+{ "a" "b" "c" } random ! Either "a", "b" or "c"
+100 random ! Random integer from 0-99 inclusive
+```
+
+### `locals`
+
+Often testing will involving generating some random value, and using it as an input to the user solution, and the reference solution. This can often get rather complex, especially when using the assertion syntax. A good solution can be to use the `locals` vocabulary, allowing values to be stored similar to imperative languages. As a short example:
+
+```factor
+1000 random :> a
+1000 random :> b
+a b + :> expected
+<{ a b add -> expected }>
+```
+
+### Parsing word limitations
+
+Kata which require the definition of parsing words can run into some problems when writing tests. Here are listed some known problems, as well as potential workarounds.
+
+#### A parsing word cannot be used in the same file it is defined in.
+
+Factor is compiled in such a way that parsing words cannot be defined and used in the same file. This is an issue for Kata which require defining a parsing word, which must be tested inside other parsing words. One potential solution to this, is to use the `<<` and `>>` [words](https://docs.factorcode.org/content/word-__lt____lt__,syntax.html) to compile a code snippet separately.
+
+#### Random tests for parsing words
+
+For some parsing words, it might be very difficult to create random tests which involve different combinations of parsing words as they might appear in real code. Tests are not run until run-time, and so all parsing will have been completed. One potential solution is to  build a string of the desired computation, use the `eval(` [word](https://docs.factorcode.org/content/word-eval(,eval.html) to compile it.
+
+### Reference solution
+
+If the test suite happens to use a reference solution to calculate expected values (which [should be avoided](/authoring/guidelines/submission-tests/#reference-solution) when possible), or some kind of reference data like precalculated arrays, etc., it must not be possible for the user to redefine, overwrite or directly access its contents. To prevent this, it ___must not___ be defined in the [Preloaded code](/authoring/guidelines/preloaded/). It should instead be defined in the [Submission tests](/authoring/guidelines/submission-tests/).
+
+## Example test suite
+
+Below you can find an example test suite (taken from [Make a Sponge](https://www.codewars.com/kata/61af4f553a27fa0057fcbc2d)) that covers most of the common scenarios mentioned in this article. Note that it does not present all possible techniques, so actual test suites can use a different structure, as long as they keep to established conventions and do not violate authoring guidelines.
+
+```factor
+USING: sponge tools.testest kernel math random accessors sequences locals classes ;
+IN: sponge.tests
+
+:: run-tests ( -- )
+  "Full tests" describe#{
+    "can instantiate sponges" it#{
+      <{ <sponge> class-of -> sponge }>
+    }#
+    <sponge> :> s
+    "can soak" it#{
+      <{ 3 s 2 soak -> s }>
+      <{ 2 6 s f soak -> 2 s }>
+      <{  t 8 7 "hello" s 11 soak -> t 8 7 s }>
+    }#
+    "can squeeze" it#{
+      <{ s squeeze -> "hello" s 11 }>
+      <{ 8 s squeeze -> 8 6 s f }>
+      <{ s squeeze -> 3 s 2 }>
+    }#
+    "can soak quotations" it#{
+      <{ [ dup ] s [ flip ] soak -> s }>
+      <{ s squeeze -> [ dup ] s [ flip ] }>
+    }#
+    "multiple sponges" it#{
+      <sponge> :> s1
+      <sponge> :> s2
+      <sponge> :> s3
+      <{ 3 3 4 s1 f soak -> 3 3 s1 }>
+      <{ t s2 t soak -> s2 }>
+      <{ s1 squeeze -> 4 s1 f }>
+      <{ 0 1 s3 2 soak 3 soak -> s3 }>
+      <{ s3 squeeze swap squeeze -> 0 3 1 s3 2 }>
+    }#
+    "can soak and squeeze other sponges" it#{
+      <sponge> :> s1
+      <sponge> :> s2
+      <sponge> :> s3
+      <{ s1 s2 s3 soak -> s2 }>
+      <{ s2 squeeze -> s1 s2 s3 }>
+    }#
+    "can soak and squeeze many things" it#{
+      <sponge> :> s1
+      <{
+      0 :> i!
+      500 [
+        i s1 i soak drop
+        i 1 + i!
+      ] times -> }>
+      <{ 375 [ s1 squeeze 3drop ] times s1 squeeze -> 124 s1 124 }>
+    }#
+
+    "Random tests" it#{
+      <sponge> :> s1
+      <sponge> :> s2
+      <sponge> :> s3
+      50 [
+        { s1 s2 s3 } random :> s
+        100 random :> n1
+        100 random :> n2
+        100 random :> n3
+        { n1 n1 n1 t f [ flip ] [ dup ] "String1" } random :> a1
+        { n2 n2 n2 t f [ + ] [ - ] "String2" } random :> a2
+        { n1 n2 n3 t f [ <sponge> ] [ soak ] "String" } random :> a3
+        <{ a3 a1 s a2 soak -> a3 s }>
+        <{ s squeeze -> a1 s a2 }>
+      ] times
+    }#
+  }#
+;
+
+MAIN: run-tests
+```

--- a/content/languages/factor/authoring.md
+++ b/content/languages/factor/authoring.md
@@ -152,7 +152,7 @@ Factor is compiled in such a way that parsing words cannot be defined and used i
 
 #### Random tests for parsing words
 
-For some parsing words, it might be very difficult to create random tests which involve different combinations of parsing words as they might appear in real code. Tests are not run until run-time, and so all parsing will have been completed. One potential solution is to  build a string of the desired computation, use the `eval(` [word](https://docs.factorcode.org/content/word-eval(,eval.html) to compile it.
+For some parsing words, it might be very difficult to create random tests which involve different combinations of parsing words as they might appear in real code. Tests are not run until run-time, and so all parsing will have been completed. One potential solution is to  build a string of the desired computation, use the `eval(` [word](https://docs.factorcode.org/content/word-eval%28,eval.html) to compile it.
 
 ### Reference solution
 

--- a/content/languages/factor/authoring.md
+++ b/content/languages/factor/authoring.md
@@ -42,7 +42,7 @@ Factor-specific paragraphs can be inserted with [language conditional rendering]
 
 ## Tasks and Requirements
 
-Some concepts don't always translate well to or from Factor. Because of this, some constructs should be avoided and some translations just shouldn't be done.
+Some concepts don't always translate well to or from Factor. Because of this some constructs should be avoided and some translations just shouldn't be done.
 - Factor has explicit stack effects, which means some Kata involving multi-variadic functions (among other things) might be difficult to translate properly.
 
 Some kata just should not be translated into Factor because it can be difficult to keep their initial idea:
@@ -67,7 +67,7 @@ IN: add-three
 Similarly, both Sample tests and Submission tests require these lines, and should each import:
 - the solution vocabulary
 - the testest vocabulary (`tools.testest`)
-- any other vocabularies required by your tests (eg. `random`)
+- any other vocabularies required by your tests (e.g. `random`)
 
 The vocabulary name of each should be the same as the solution vocabulary, with an additional `.tests` suffix.
 
@@ -133,7 +133,7 @@ The `random` [vocabulary](https://docs.factorcode.org/content/vocab-random.html)
 
 ### `locals`
 
-Often testing will involving generating some random value, and using it as an input to the user solution, and the reference solution. This can often get rather complex, especially when using the assertion syntax. A good solution can be to use the `locals` vocabulary, allowing values to be stored similar to imperative languages. As a short example:
+Often testing will involve generating some random value, and using it as an input to the user solution, and the reference solution. This can often get rather complex, especially when using the assertion syntax. A good solution can be to use the `locals` vocabulary, allowing values to be stored similar to imperative languages. As a short example:
 
 ```factor
 1000 random :> a
@@ -144,7 +144,7 @@ a b + :> expected
 
 ### Parsing word limitations
 
-Kata which require the definition of parsing words can run into some problems when writing tests. Here are listed some known problems, as well as potential workarounds.
+Kata which involve defining parsing words can run into some problems when writing tests. Here are listed some known problems, as well as potential workarounds.
 
 #### A parsing word cannot be used in the same file it is defined in.
 

--- a/content/languages/factor/authoring.md
+++ b/content/languages/factor/authoring.md
@@ -76,7 +76,7 @@ USING: add-three tools.testest kernel math ;
 IN: add-three.tests
 ```
 
-#### Test grouping functions
+#### Test grouping words
 
 To create and present test output, testest uses the `describe#{` and `it#{` words:
 
@@ -131,15 +131,33 @@ The `random` [vocabulary](https://docs.factorcode.org/content/vocab-random.html)
 100 random ! Random integer from 0-99 inclusive
 ```
 
-### `locals`
+### Recipe: Generating random tests
 
-Often testing will involve generating some random value, and using it as an input to the user solution, and the reference solution. This can often get rather complex, especially when using the assertion syntax. A good solution can be to use the `locals` vocabulary, allowing values to be stored similar to imperative languages. As a short example:
+The following words can useful in writing concise and understand random tests:
+- Binding lexical variables with [`:>`](https://docs.factorcode.org/content/word-__colon____gt__,syntax.html) makes it much easier to use randomly generated values in multiple places.
+- Test group labels can be formatted with [`vsprintf`](https://docs.factorcode.org/content/word-vsprintf,formatting.html) to include inputs (where appropriate)
+- Tests can be run in a loop using [`times`](https://docs.factorcode.org/content/word-times,math.html).
+
+Using these, a batch of random tests might look something like the following example:
 
 ```factor
-1000 random :> a
-1000 random :> b
-a b + :> expected
-<{ a b add -> expected }>
+USING: multiply tools.testest kernel random math formatting locals ;
+IN: multiply.tests
+
+:: run-tests ( -- )
+  "Random tests" describe#{
+    50 [
+      100 random :> a
+      100 random :> b
+      a b * :> expected
+      { a b } "Testing a=%d b=%d" vsprintf it#{
+        <{ a b multiply -> expected }>
+      }#
+    ] times
+  }#
+;
+
+MAIN: run-tests
 ```
 
 ### Parsing word limitations

--- a/content/languages/factor/testest.md
+++ b/content/languages/factor/testest.md
@@ -44,7 +44,7 @@ MAIN: run-tests
 
 #### `<{ ...inputs -> ...expected }>`
 
-  Creates a unit test, by executing the values in `...inputs`, then executing the values in `...expected` and comparing the results. If these results match then the test is passed, otherwise it is failed.
+  Creates a unit test, by executing the values in `...inputs`, then executing the values in `...expected` and comparing the resulting stacks. If they match, the test is passed, otherwise the test is failed. On failure, the stacks are packed into a tuple (under `got` and `expected` slots, respectively) and pushed onto the stack to be available for the `test-failed.` quotation.
 
 #### `test-passed.`
 

--- a/content/languages/factor/testest.md
+++ b/content/languages/factor/testest.md
@@ -9,6 +9,50 @@ tags:
 
 # testest
 
+To run Factor tests, Codewars currently uses a custom test vocabulary, published and available in [this GitHub repository][test-framework-repo].
+
+## Basic Usage
+
+```factor
+USING: solution-vocabulary tools.testest ;
+IN: solution-vocabulary.tests
+
+: run-tests ( -- )
+  "Example Tests" describe#{
+    "Example test case" it#{
+      <{ 1 1 add -> 2 }>
+    }#
+
+    "Another test case" it#{
+     <{ 3 double -> 6 }>
+     <{ 0 double -> 0 }>
+    }#
+  }#
+
+MAIN: run-tests
+```
+
+## Words and Syntax
+
+#### `describe#{`
+
+  Starts a new block of tests, taking a string off the stack as the title of the block. Terminated with the `}#` word.
+
+#### `it#{`
+
+  Starts a new assertion block, taking a string off the stack as the title of the block. Terminated with the `}#` word.
+
+#### `<{ ...inputs -> ...expected }>`
+
+  Creates an assertion, by seqentially executing the values in `...inputs` and comparing the resulting stack with `...expected`.
+
+## Acknowledgements
+
+`testest` was authored by [@nomennescio](https://github.com/nomennescio).
+
+[test-framework-repo]: https://github.com/codewars/testest
+
+
 <!--
 TODO: Finish this reference
 TODO: Add tutorial and link to it

--- a/content/languages/factor/testest.md
+++ b/content/languages/factor/testest.md
@@ -40,11 +40,19 @@ MAIN: run-tests
 
 #### `it#{`
 
-  Starts a new assertion block, taking a string off the stack as the title of the block. Terminated with the `}#` word.
+  Starts a new test group, taking a string off the stack as the title of the block. Terminated with the `}#` word.
 
 #### `<{ ...inputs -> ...expected }>`
 
-  Creates an assertion, by seqentially executing the values in `...inputs` and comparing the resulting stack with `...expected`.
+  Creates a unit test, by executing the values in `...inputs`, then executing the values in `...expected` and comparing the results. If these results match then the test is passed, otherwise it is failed.
+
+#### `test-passed.`
+
+  `test-passed.` is a symbol which is bound to a quotation with stack effect `( -- )`. When a unit test passes, this quotation will be called. This can be used to create [custom result messages](/languages/factor/authoring#custom-result-messages).
+
+#### `test-failed.`
+
+`test-passed.` is a symbol which is bound to a quotation with stack effect `( assert-sequence -- )`. When a unit test fails, the values on the left and right side of the test will be collected into sequences, and stored in tuple under slots `got` and `expected` respectively. This tuple will be pushed onto the stack, and then this quotation will be called. This can be used to create [custom result messages](/languages/factor/authoring#custom-result-messages).
 
 ## Acknowledgements
 

--- a/content/languages/python/codewars-test.mdx
+++ b/content/languages/python/codewars-test.mdx
@@ -1,6 +1,6 @@
 ---
 title: Python Codewars Test Framework
-siebar_label: Codewars Test Framework
+sidebar_label: Codewars Test Framework
 kind: reference
 ---
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -210,7 +210,7 @@ module.exports = {
         {
           type: "category",
           label: "Factor",
-          items: ["languages/factor/index", "languages/factor/testest"],
+          items: ["languages/factor/index", "languages/factor/authoring", "languages/factor/testest"],
         },
         {
           type: "category",


### PR DESCRIPTION
I roughly used the existing JavaScript guide as a template, and also added some Factor specific content.

I thought perhaps nomennescio could look over it for errors or changes, but it might be easier to "pull now, fix later" so that he can read directly in the docs.

Preview: [here](https://deploy-preview-367--reverent-edison-2864ea.netlify.app/languages/factor/authoring)