### PR TITLE
haskell: Include QuickCheck

### DIFF
--- a/content/languages/haskell/index.md
+++ b/content/languages/haskell/index.md
@@ -63,6 +63,7 @@ dependencies:
 - persistent
 - persistent-sqlite
 - persistent-template
+- QuickCheck
 - random
 - regex-pcre
 - regex-posix


### PR DESCRIPTION
QuickCheck has been always available, but it's a transitive dependency
and not listed in `package.yaml`. It will be installed explicitly in the
next version.