### PR TITLE
Hide glossary from sidebar for now

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -486,7 +486,7 @@ module.exports = {
         "references/kata-trainer",
       ],
     },
-    "glossary",
+    // "glossary",
     {
       type: "category",
       label: "Meta",


### PR DESCRIPTION
We need to either:
- generate a page from `glossary.yml` like before, or
- switch to Markdown and manually maintain order and headers
  - can write a script to migrate