### PR TITLE
Avoid assertEquals and clarify PHP

### DIFF
--- a/content/languages/php/phpunit.md
+++ b/content/languages/php/phpunit.md
@@ -9,6 +9,28 @@ tags:
 
 # PHPUnit
 
+All [PHPUnit](https://phpunit.readthedocs.io/) tests start with a subclass of `TestCase`. You can then add one or more test case methods to that class, each of which must be public and start with `test`. In Codewars' PHP versions 7.4+, PHPUnit requires the name of the test class to end with `Test`.
+
+Note that PHPUnit's `assertEqual` call uses the parameter order `($expected, $actual)`, unlike most testing libraries which have `$actual` first.
+
+## Basic Setup
+
+```php
+function add(int $a, int $b): int {
+    return $a + $b;
+}
+```
+
+```php
+class AddTest extends TestCase {
+    public function testAdd() {
+        $expected = 3;
+        $actual = add(1, 2);
+        $this->assertEquals($expected, $actual);
+    }
+}
+```
+
 <!--
 TODO: Finish this reference
 TODO: Add tutorial and link to it

--- a/content/languages/php/phpunit.md
+++ b/content/languages/php/phpunit.md
@@ -11,7 +11,7 @@ tags:
 
 All [PHPUnit](https://phpunit.readthedocs.io/) tests start with a subclass of `TestCase`. You can then add one or more test case methods to that class, each of which must be public and start with `test`. In Codewars' PHP versions 7.4+, PHPUnit requires the name of the test class to end with `Test`.
 
-Note that PHPUnit's `assertEqual` call uses the parameter order `($expected, $actual)`, unlike most testing libraries which have `$actual` first.
+Note that PHPUnit's assertions follow the parameter order `($expected, $actual)`, unlike most testing libraries which have `$actual` first.
 
 ## Basic Setup
 

--- a/content/languages/php/phpunit.md
+++ b/content/languages/php/phpunit.md
@@ -11,8 +11,6 @@ tags:
 
 All [PHPUnit](https://phpunit.readthedocs.io/) tests start with a subclass of `TestCase`. You can then add one or more test case methods to that class, each of which must be public and start with `test`. In Codewars' PHP versions 7.4+, PHPUnit requires the name of the test class to end with `Test`.
 
-Note that PHPUnit's assertions follow the parameter order `($expected, $actual)`, unlike most testing libraries which have `$actual` first.
-
 ## Basic Setup
 
 ```php
@@ -26,10 +24,59 @@ class AddTest extends TestCase {
     public function testAdd() {
         $expected = 3;
         $actual = add(1, 2);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 }
 ```
+
+## Assertions
+
+### Argument order
+
+PHPUnit's assertions follow the parameter order `($expected, $actual)`, unlike most testing libraries which have `$actual` first.
+
+### Primitive equality
+
+[`assertEquals`](https://phpunit.readthedocs.io/en/9.5/assertions.html#assertequals) has surprising behavior on primitives due to casting and loose equality. Here are sample comparisons that `assertEquals` considers equal:
+
+```
+$this->assertEquals("1", "001");
+$this->assertEquals(1, "001");
+$this->assertEquals(42, true);
+$this->assertEquals("42", true);
+$this->assertEquals(0, false);
+$this->assertEquals([["foo" => 1]], [["foo" => "1"]]);
+```
+
+[`assertSame`](https://phpunit.readthedocs.io/en/9.5/assertions.html#assertsame) fails all of the above checks, as one would likely want. `assertEquals` should be avoided due to its surprising behavior.
+
+### Object equality
+
+It's tempting to use `assertSame` across the board, but its identity check is too strict for most object comparisons:
+
+```php
+$expected = new stdClass;
+$expected->foo = "foo";
+$expected->bar = "42";
+$actual = new stdClass;
+$actual->foo = "foo";
+$actual->bar = "42";
+$this->assertSame($expected, $actual); // fails
+```
+
+Here, using [`assertObjectsEqual`](https://phpunit.readthedocs.io/en/9.5/assertions.html#assertobjectequals), which calls a class' `equals(self $other): bool` method, might be a more appropriate approach.
+
+### Float equality
+
+For float comparisons, [`assertEqualsWithDelta`](https://phpunit.readthedocs.io/en/9.5/assertions.html#assertequalswithdelta) has similar unpredictable behavior as `assertEquals`:
+
+```php
+$this->assertEqualsWithDelta(0.99, "1", 0.1); // passes
+$this->assertEqualsWithDelta(99999, true, 0.1); // passes
+```
+
+Implementing a custom delta assertion based on `assertTrue` may be a safer bet.
+
 
 <!--
 TODO: Finish this reference

--- a/content/languages/php/phpunit.md
+++ b/content/languages/php/phpunit.md
@@ -75,7 +75,7 @@ $this->assertEqualsWithDelta(0.99, "1", 0.1); // passes
 $this->assertEqualsWithDelta(99999, true, 0.1); // passes
 ```
 
-Implementing a custom delta assertion based on `assertTrue` may be a safer bet.
+Type-checking the arguments to `assertEqualsWithDelta` before calling it or implementing a custom delta assertion based on `assertTrue` may be a safer bet.
 
 
 <!--


### PR DESCRIPTION
See comments in #399: https://github.com/codewars/docs/pull/399#pullrequestreview-1011406669. This PR clarifies the surprising behavior of `assertEquals` and provides a few alternatives.