### PR TITLE
Add RISC-V to the list of Beta languages

### DIFF
--- a/content/languages/index.md
+++ b/content/languages/index.md
@@ -64,6 +64,7 @@ sidebar_position: 0
 - [R](/languages/r)
 - [Raku](/languages/raku)
 - [Reason](/languages/reason)
+- [RISC-V](/languages/riscv)
 - [Solidity](/languages/solidity)
 - [VB.NET](/languages/vb)
 

--- a/content/languages/riscv/cgreen.md
+++ b/content/languages/riscv/cgreen.md
@@ -13,7 +13,7 @@ Unit tests for RISC-V are written in C with [Cgreen](https://cgreen-devs.github.
 
 ### Solution
 
-```asm
+```riscv
 .globl add
 add:
   addw a0, a0, a1

--- a/content/languages/riscv/cgreen.md
+++ b/content/languages/riscv/cgreen.md
@@ -1,0 +1,43 @@
+---
+tags:
+  - riscv
+  - reference
+  - testing
+---
+
+# Cgreen
+
+Unit tests for RISC-V are written in C with [Cgreen](https://cgreen-devs.github.io/cgreen/) while the solution file is in assembly.
+
+## Basic Setup
+
+### Solution
+
+```asm
+.globl add
+add:
+  addw a0, a0, a1
+  ret
+```
+
+### Tests
+
+```c
+#include <cgreen/cgreen.h>
+
+int add(int, int);
+
+Describe(Add);
+BeforeEach(Add) {}
+AfterEach(Add) {}
+
+Ensure(Add, should_add_integers) {
+  assert_that(add(1, 1), is_equal_to(2));
+}
+
+TestSuite *solution_tests() {
+  TestSuite *suite = create_test_suite();
+  add_test_with_context(suite, Add, should_add_integers);
+  return suite;
+}
+```

--- a/content/languages/riscv/index.md
+++ b/content/languages/riscv/index.md
@@ -1,0 +1,35 @@
+---
+title: RISC-V
+sidebar_label: Overview
+slug: /languages/riscv
+---
+
+## Status
+
+Beta
+
+## Version
+
+RV64
+
+Codewars uses [QEMU user mode emulation](https://www.qemu.org/docs/master/user/main.html) to support RISC-V content. The [RISC-V `virt` board in QEMU full system emulation](https://www.qemu.org/docs/master/system/riscv/virt.html) implements **RV64IMAFDC**, also known as **RV64GC**. This is likely the case for user mode emulation as well but is not officially documented at the time of writing (2022-08-21).
+
+## Test Frameworks
+
+[Cgreen](https://cgreen-devs.github.io/cgreen/)
+
+## Timeout
+
+12 seconds
+
+## Packages
+
+Cgreen test framework (`libcgreen`)
+
+## Services
+
+None
+
+## Language ID
+
+`riscv`

--- a/sidebars.js
+++ b/sidebars.js
@@ -613,15 +613,15 @@ module.exports = {
           },
           items: ["languages/reason/jest"],
         },
-	{
+        {
           type: "category",
           label: "RISC-V",
           link: {
             type: "doc",
             id: "languages/riscv/index",
-	  },
+          },
           items: ["languages/riscv/cgreen"],
-	},
+        },
         {
           type: "category",
           label: "Ruby",

--- a/sidebars.js
+++ b/sidebars.js
@@ -620,7 +620,7 @@ module.exports = {
             type: "doc",
             id: "languages/riscv/index",
 	  },
-          items: [],
+          items: ["languages/riscv/cgreen"],
 	},
         {
           type: "category",

--- a/sidebars.js
+++ b/sidebars.js
@@ -613,6 +613,11 @@ module.exports = {
           },
           items: ["languages/reason/jest"],
         },
+	{
+          type: "category",
+          label: "RISC-V",
+          items: ["languages/riscv/index"],
+	},
         {
           type: "category",
           label: "Ruby",

--- a/sidebars.js
+++ b/sidebars.js
@@ -616,6 +616,10 @@ module.exports = {
 	{
           type: "category",
           label: "RISC-V",
+          link: {
+            type: "doc",
+            id: "languages/riscv/index",
+	  },
           items: ["languages/riscv/index"],
 	},
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -620,7 +620,7 @@ module.exports = {
             type: "doc",
             id: "languages/riscv/index",
 	  },
-          items: ["languages/riscv/index"],
+          items: [],
 	},
         {
           type: "category",


### PR DESCRIPTION
Closes #438 

Closes #439

It might be better to address #440 after modifying `bin/run` in [codewars/riscv](https://github.com/codewars/riscv) to allow text output when solving locally.