### PR TITLE
Updating the kata rank descriptions.

### DIFF
--- a/content/curation/references/kata-ranks.md
+++ b/content/curation/references/kata-ranks.md
@@ -1,105 +1,101 @@
+<!--TO DO: Still need to ask authors for permission -->
 ---
 title: Kata Ranks
 slug: /curation/references/kata-ranks
 ---
 
 :::warning
-The rank definitions on this page is outdated.
+The rank definitions on this page are being updated, and are subject to change at any time.
 :::
-
-<!--
-More detailed draft:
-https://docs.google.com/document/d/1eseD5xyhGdtQ-DaWdqfK2yf6mvTDWHWEpkQGBppI8cw
--->
 
 ## White (Beginner)
 
 ### 8 Kyu
 
-8 kyu kata represent a beginner level.
-At this level, the kata are only challenging for users new to programming.
-This includes programming tasks such as:
-
-- Defining a simple function (i.e. hello world)
-- Basic variable assignments
-- Fixing basic syntax issues
-- Trivial algorithms such as basic if/else statements
+8 kyu kata are for coders at the beginning of their programming journey. 
+At this level, tasks should only be challenging for users new to coding. 
+For example:
+- Defining a function, such as [hello world](https://www.codewars.com/kata/523b4ff7adca849afe000035) or [alternating case](https://www.codewars.com/kata/56efc695740d30f963000557).
+- Basic variable handling, including skills like [type conversion](https://www.codewars.com/kata/544675c6f971f7399a000e79), [string manipulation](https://www.codewars.com/kata/56bc28ad5bdaeb48760009b0), and [array analysis](https://www.codewars.com/kata/563e320cee5dddcf77000158/).
+- Fixing [basic syntax issues](https://www.codewars.com/kata/55cb854deb36f11f130000e1).
+- Trivial language features, such as [basic if/else statements](https://www.codewars.com/kata/53369039d7ab3ac506000467).
 
 ### 7 Kyu
 
-7 kyu kata represent a beginner programming level.
-At this level, the kata will generally challenge users on their core language and API reference knowledge.
-Tasks such as:
+7 kyu kata are tasks for programmers with more experience than total beginners but are still relatively new to computer science.  
+The kata on this level should generaly test the user's knowledge of the core language and API.
 
-- Iterating arrays and returning a subset of values
-- Basic data type manipulations
-- Basic functional or object-oriented concepts
-- Basic Regular Expressions
+Some notable 7 kyu kata categories include:
+- Iterating over [arrays](https://www.codewars.com/kata/53d32bea2f2a21f666000256), [numbers](https://www.codewars.com/kata/5300901726d12b80e8000498),or [strings](https://www.codewars.com/kata/54ff3102c1bad923760001f3) to return a specified [quantity](https://www.codewars.com/kata/57a1d5ef7cb1f3db590002af) or [subset](https://www.codewars.com/kata/53dbd5315a3c69eed20002dd).  
+- [Algorithms](https://www.codewars.com/kata/56a6ce697c05fb4667000029) that aren't performance-intensive.
+- Basic [logical](https://www.codewars.com/kata/5cb9dc6f98b230001cbe2cea), [functional](https://www.codewars.com/kata/5413759479ba273f8100003d), or [object-oriented](https://www.codewars.com/kata/513f887e484edf3eb3000001) concepts. <!-- I felt like I should include some of the proof-languages in here -->
+- [Basic Regular Expressions](https://www.codewars.com/kata/6361bdb5d41160000ee6db86).<!--shameless self promotion :-)-->
 
-## Yellow (Novice)
+## Yellow (Intermediate)
 
 ### 6 Kyu
 
-6 kyu kata represent a novice programming level. At this level, the kata will start to include more advanced algorithmic challenges and more complex language features. It includes:
+6 kyu kata represents the start of more complex problems and solutions.  At this level, the kata will start to include more advanced algorithmic challenges and more complicated language features. Some examples of these include:
 
-- Complex language features (closures, scopes, monads, etc)
-- Complex OOP/Functional concepts
-- Basic Design Patterns
-- Complex Regular Expressions
+- A grasp of [more lengthy descriptions and requirements](https://www.codewars.com/kata/626d96eb49cb3c7a2f634bbf).
+- A complex [functional](https://www.codewars.com/kata/58aa5d32c9eb04d90b000107) concept or idea.
+- [Puzzles](https://www.codewars.com/kata/63753f7f64c31060a564e790) that some require research or experimentation. 
+- Basic [Real World Design Patterns](https://www.codewars.com/kata/5266876b8f4bf2da9b000362).
+- [Algorithms](https://www.codewars.com/kata/541c8630095125aba6000c00) require some thinking, but usually don't expect efficiency. 
+- [Competent use of Regular Expressions](https://www.codewars.com/kata/5e4eb72bb95d28002dbbecde).
 
 ### 5 Kyu
 
-5 kyu kata represent a novice programming level.
-At this level, the kata are similar to 6 kyu but more challenging.
-It includes:
+5 kyu kata is when tasks start to challenge the programmers' logical reasoning through an increased level of difficulty and skill requirements.
+At this level, a trainee is expected to have a general grasp of the language they are coding in. 5 kyu kata include tasks requiring:
 
-- Complex language features that require mature OOP/Functional concepts
-- Advanced OOP/Functional concepts
-- Complex Design Patterns
-- Advanced regular expression usage
+- Using several [complex language concepts](https://www.codewars.com/kata/62fa7b95eb6d08fa9468b384) to achieve a goal.
+- Advanced [OOP](https://www.codewars.com/kata/515bb423de843ea99400000a) concepts.
+- [Complex Design Patterns](https://www.codewars.com/kata/58678d29dbca9a68d80000d7)
+- [Advanced string manipulation](https://www.codewars.com/kata/54a91a4883a7de5d7800009c) and a strong knowledge of [Regular Expressions](https://www.codewars.com/kata/52e1476c8147a7547a000811).
 
-## Blue (Competent)
+## Blue (Advanced) <!-- I felt that "competent" was a tad bit harsh; That would imply anybody less then 4 kyu arn't capable or statisfactory -->
 
 ### 4 Kyu
 
-4 kyu kata represent a competent programming level.
-At this level, the kata begin to take some serious thought to complete.
+4 kyu kata represent experienced programming levels.
+At this level, the kata begins to take some serious thought to complete.
 They include tasks that may handle:
 
-- Computer science concepts utilizing complex algorithms
-- Advanced design patterns
-- Understanding intricate business requirements
-- Advanced concepts such as concurrency, parallelism, meta programming and cryptography
-
+- Complex algorithms that require both [speed](https://www.codewars.com/kata/621f89cc94d4e3001bb99ef4) and [efficency](https://www.codewars.com/kata/5254ca2719453dcc0b00027d).
+- [Advanced design patterns](https://www.codewars.com/kata/51b66044bce5799a7f000003) for [real world applications](https://www.codewars.com/kata/52742f58faf5485cae000b9a)
+- [Problem-solving katas](https://www.codewars.com/kata/529bf0e9bdf7657179000008) that require thought investment.
+- Understanding [intricate project requirements](https://www.codewars.com/kata/62e068c14129156a2e0df46a).
+- Tasks that require research of [high-level math equations](https://www.codewars.com/kata/6357205000fba205ed189a52/python).
 ### 3 Kyu
 
-3 kyu kata represent a competent programming level.
-At this level, the kata are similar to 4 kyu but are more challenging.
-They include tasks that may handle:
+3 kyu kata represent an advanced understanding of programming and contain tasks and difficulties to parallel the coder's skills. 
+As the complexity of the challenges increases, the solutions to the kata tend to become significantly longer. 
+Such challenges are:
 
-- Computer science concepts utilizing advanced algorithms
-- Ability to implement advanced requirements in a scalable fashion
-- Basic AI/machine learning algorithms
-- Detailed usage of advanced concepts such as concurrency, parallelism and cryptography
+- [Performance-heavy tasks](https://www.codewars.com/kata/54cb771c9b30e8b5250011d4) utilizing [advanced algorithms](https://www.codewars.com/kata/5518a860a73e708c0a000027).
+- Ability to implement [elaborate requirements](https://www.codewars.com/kata/5861487fdb20cff3ab000030) in a scalable fashion.
+- Programs for solving puzzles and games, such as [sudoku](https://www.codewars.com/kata/5296bc77afba8baa690002d7) or [battleship](https://www.codewars.com/kata/52bb6539a4cf1b12d90005b7).
+- Detailed usage of advanced concepts such as [metaprogramming](https://www.codewars.com/kata/5571d9fc11526780a000011a), [combinatorics](https://www.codewars.com/kata/585894545a8a07255e0002f1) and [cryptography](https://www.codewars.com/kata/58c5577d61aefcf3ff000081).
 
-## Purple (Proficient)
+## Purple (Expert)
 
 ### 2 Kyu
 
-2 kyu kata represent a proficient programming level.
-At this level, kata require a mature understanding of complex programming concepts - concepts such as:
+2 kyu kata represent a professional programming level. Tasks at these levels start to become mini-projects, as each of the requirements for the main solution becomes challanges of their own. At this level, kata requires a mature understanding of several intricate programming concepts - concepts such as:
 
-- Complex AI/machine learning algorithms
-- Reverse engineering techniques
-- Basic interpreters and compilers
-- Basic mini-programs with multiple feature requirements (such as a basic Markdown parser)
+- Extreme-[performance](https://www.codewars.com/kata/5a5072a6145c46568800004d), [efficiency](https://www.codewars.com/kata/5908242330e4f567e90000a3), or [math](https://www.codewars.com/kata/5a331ea7ee1aae8f24000175) heavy algorithms.
+- Engineering complete [games](https://www.codewars.com/kata/5679d5a3f2272011d700000d) and [puzzles](https://www.codewars.com/kata/5b86a6d7a4dcc13cd900000b) with tricky or exacting rules and requirements. 
+- Basic [interpreters](https://www.codewars.com/kata/58e61f3d8ff24f774400002c), [parsers](https://www.codewars.com/kata/52a78825cdfc2cfc87000005), and [compilers](https://www.codewars.com/kata/597ccf7613d879c4cb00000f).
+- A mature use of [OOP](https://www.codewars.com/kata/5a27ca7ab6cfd70f9300007a) and [logic](https://www.codewars.com/kata/5ca40e41bfaf24001980d07a) to accomplish a desired goal. 
 
 ### 1 Kyu
 
-1 kyu kata represent a proficient programming level.
-At this level, kata are similar to 2 kyu but more challenging.
+1 kyu kata represents a general mastery of computer science. Tasks that achieve this level require a significant level of time and thought to complete, as the requirements are both demanding and sophisticated.
+At this level, kata requires experience, patience, and a wide range of skills ready to solve the problem.
 They may include concepts such as:
 
-- Advanced AI/machine learning algorithms
-- Complex interpreters and compilers
-- Complex Mini-programs with multiple feature requirements (such as a complete Markdown parser)
+- [Thorough performance algorithms](https://www.codewars.com/kata/5976c5a5cd933a7bbd000029) that need to quickly untangle a multitude of [large data values](https://www.codewars.com/kata/59568be9cc15b57637000054).
+- Advanced [games](https://www.codewars.com/kata/5ea6a8502186ab001427809e) and [puzzles](https://www.codewars.com/kata/5a20eeccee1aae3cbc000090) that need to be constructed in a detailed fashion.
+- Complex [interpreters](https://www.codewars.com/kata/52ffcfa4aff455b3c2000750) and [compilers](https://www.codewars.com/kata/59f9cad032b8b91e12000035).
+- Implementation of [mini-programs](https://www.codewars.com/kata/5a12755832b8b956a9000133) with [multiple feature requirements](https://www.codewars.com/kata/591f3a2a6368b6658800020).


### PR DESCRIPTION
- Removed examples that aren't relevant (e.g There is currently only one task under the Concurrency tag)
- Added links to kata showing examples of the topics. I tried to pick quality kata without, but a few need to be updated to new js and python frameworks. 
- I changed the color descriptions to be a little less harsh (Beginner->Beginner, Novice->Intermediate, Competent->Advanced, Proficient->Expert)
- I mixed up the word variety a bit. I am in my 1st year of programming; you might want to review the Kyu challenge-level descriptions for accuracy (e.g Idk if 2kyu is actually a professional rank. )
- Let me know if I need to ask the authors for permission, I understand if someone doesn't want their kata displayed for example.