### PR TITLE
Recipe: OUnit assertions

### DIFF
--- a/content/languages/ocaml/recipes.md
+++ b/content/languages/ocaml/recipes.md
@@ -1,0 +1,36 @@
+---
+title: OCaml recipes for Codewars
+tags: [authoring, recipe, ocaml]
+---
+
+
+## Informative assertion messages
+
+Default assertion messages of OCaml OUnit are usually very bad. OUnit assertons accept two optional, named arguments:
+- `~printer`, used to stringify values presented by assertion messages.
+- `~msg`, used to provide additional information about failure, if necessary.
+
+With both arguments used, test output becomes more explicit:
+
+```ocaml
+"(square 3) should return 9" >:: (fun _ ->
+  let actual = square 3 in
+  assert_equal 9 actual ~printer: string_of_int ~msg: "Incorrect answer for n=3"
+)
+```
+
+```text
+Time: 1083ms Passed: 0Failed: 1Exit Code: 1
+  Test Results:
+    Tests for square
+      (square 3) should return 9
+        Incorrect answer for n=3
+        expected: 9 but got: 10
+    Completed in 0.24ms
+  Completed in 0.26ms
+```
+
+### References
+
+- [Improving OUnit Output](https://cs3110.github.io/textbook/chapters/data/ounit.html#improving-ounit-output)
+- [OUnit: xUnit testing framework for OCaml](https://gildor478.github.io/ounit/ounit2/index.html#error-reporting)

--- a/sidebars.js
+++ b/sidebars.js
@@ -512,7 +512,10 @@ module.exports = {
             type: "doc",
             id: "languages/ocaml/index",
           },
-          items: ["languages/ocaml/ounit"],
+          items: [
+            "languages/ocaml/ounit",
+            "languages/ocaml/recipes"
+          ],
         },
         {
           type: "category",


### PR DESCRIPTION
Since authors often do not bother to check output of failing tests and are not aware of how bad the default assertion messages are with OUnit, I created this recipe to post it as links in problematic translations.