### PR TITLE
Update RISC-V ISA documentation

### DIFF
--- a/content/languages/riscv/index.md
+++ b/content/languages/riscv/index.md
@@ -29,10 +29,10 @@ Codewars uses [QEMU user mode emulation](https://www.qemu.org/docs/master/user/m
     - `Zks` - ShangMi
 
 The most recent version of the specification for each can be downloaded below (as of 26 Dec 2023):
-- <sup>*</sup><a href="https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf" download rel="external" type="application/pdf">RISC-V Unprivileged Specification</a>
-- <sup>†</sup><a href="https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf" download rel="external" type="application/pdf">Vector Extension Specification</a>
-- <sup>‡</sup><a href="https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0.pdf" download rel="external" type="application/pdf">Bit-Manipulation Extension Specification</a>
-- <sup>§</sup><a href="https://github.com/riscv/riscv-crypto/releases/download/v1.0.1-scalar/riscv-crypto-spec-scalar-v1.0.1.pdf" download rel="external" type="application/pdf">Cryptography Extension Specification</a>
+- <sup>*</sup><a href="https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf">RISC-V Unprivileged Specification</a>
+- <sup>†</sup><a href="https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf">Vector Extension Specification</a>
+- <sup>‡</sup><a href="https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0.pdf">Bit-Manipulation Extension Specification</a>
+- <sup>§</sup><a href="https://github.com/riscv/riscv-crypto/releases/download/v1.0.1-scalar/riscv-crypto-spec-scalar-v1.0.1.pdf">Cryptography Extension Specification</a>
 
 ## Test Frameworks
 

--- a/content/languages/riscv/index.md
+++ b/content/languages/riscv/index.md
@@ -10,9 +10,27 @@ Beta
 
 ## Version
 
-RV64
+RV64GCV_Zba_Zbb_Zbc_Zbs_Zbkx_Zk_Zks
 
-Codewars uses [QEMU user mode emulation](https://www.qemu.org/docs/master/user/main.html) to support RISC-V content. The [RISC-V `virt` board in QEMU full system emulation](https://www.qemu.org/docs/master/system/riscv/virt.html) implements **RV64IMAFDC**, also known as **RV64GC**. This is likely the case for user mode emulation as well but is not officially documented at the time of writing (2022-08-21).
+Codewars uses [QEMU user mode emulation](https://www.qemu.org/docs/master/user/main.html) to support RISC-V content. Codewars is configured to use the following extensions for RISC-V:
+- `G` - General-Purpose*
+- `C` - Compressed*
+- `V` - Vector*†
+- Zb* - Bit-Manipulation‡
+    - `Zba` - Address Generation
+    - `Zbb` - Basic
+    - `Zbc` - Carry-less
+    - `Zbs` - Single-bit
+- Cryptography - Scalar§
+    - `Zbkx` - Crossbar permutation
+    - `Zk` - Standard
+    - `Zks` - ShangMi
+
+The most recent (26 Dec 2023) version of the specification for each can be downloaded below:
+- \*[RISC-V Unprivileged Specification](https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf)
+- †[Vector Extension Specification](https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf)
+- ‡[Bit-Manipulation Extension Specification](https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0.pdf)
+- §[Cryptography Extension Specification](https://github.com/riscv/riscv-crypto/releases/download/v1.0.1-scalar/riscv-crypto-spec-scalar-v1.0.1.pdf)
 
 ## Test Frameworks
 

--- a/content/languages/riscv/index.md
+++ b/content/languages/riscv/index.md
@@ -29,7 +29,7 @@ Codewars uses [QEMU user mode emulation](https://www.qemu.org/docs/master/user/m
     - `Zks` - ShangMi
 
 The most recent version of the specification for each can be downloaded below (as of 26 Dec 2023):
-- <sup>*</sup>[RISC-V Unprivileged Specification](https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf)
+- <sup>*</sup><a href="https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf" >RISC-V Unprivileged Specification</a>
 - <sup>†</sup>[Vector Extension Specification](https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf)
 - <sup>‡</sup>[Bit-Manipulation Extension Specification](https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0.pdf)
 - <sup>§</sup>[Cryptography Extension Specification](https://github.com/riscv/riscv-crypto/releases/download/v1.0.1-scalar/riscv-crypto-spec-scalar-v1.0.1.pdf)

--- a/content/languages/riscv/index.md
+++ b/content/languages/riscv/index.md
@@ -28,7 +28,7 @@ Codewars uses [QEMU user mode emulation](https://www.qemu.org/docs/master/user/m
     - `Zk` - Standard
     - `Zks` - ShangMi
 
-The most recent (26 Dec 2023) version of the specification for each can be downloaded below:
+The most recent version of the specification for each can be downloaded below (as of 26 Dec 2023):
 - \*[RISC-V Unprivileged Specification](https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf)
 - †[Vector Extension Specification](https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf)
 - ‡[Bit-Manipulation Extension Specification](https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0.pdf)

--- a/content/languages/riscv/index.md
+++ b/content/languages/riscv/index.md
@@ -15,24 +15,24 @@ QEMU Toolchain: QEMU 7.1, GCC 11.3.0, Binutils 2.38
 ISA String: RV64GCV_Zba_Zbb_Zbc_Zbs_Zbkx_Zk_Zks
 
 Codewars uses [QEMU user mode emulation](https://www.qemu.org/docs/master/user/main.html) to support RISC-V content. Codewars is configured to use the following extensions for RISC-V:
-- `G` - General-Purpose*
-- `C` - Compressed*
-- `V` - Vector*†
-- Zb* - Bit-Manipulation‡
+- `G` - General-Purpose<sup>*</sup>
+- `C` - Compressed<sup>*</sup>
+- `V` - Vector<sup>*†</sup>
+- Zb* - Bit-Manipulation<sup>‡</sup>
     - `Zba` - Address Generation
     - `Zbb` - Basic
     - `Zbc` - Carry-less
     - `Zbs` - Single-bit
-- Cryptography - Scalar§
+- Cryptography - Scalar<sup>§</sup>
     - `Zbkx` - Crossbar permutation
     - `Zk` - Standard
     - `Zks` - ShangMi
 
 The most recent version of the specification for each can be downloaded below (as of 26 Dec 2023):
-- \*[RISC-V Unprivileged Specification](https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf)
-- †[Vector Extension Specification](https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf)
-- ‡[Bit-Manipulation Extension Specification](https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0.pdf)
-- §[Cryptography Extension Specification](https://github.com/riscv/riscv-crypto/releases/download/v1.0.1-scalar/riscv-crypto-spec-scalar-v1.0.1.pdf)
+- <sup>*</sup>[RISC-V Unprivileged Specification](https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf)
+- <sup>†</sup>[Vector Extension Specification](https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf)
+- <sup>‡</sup>[Bit-Manipulation Extension Specification](https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0.pdf)
+- <sup>§</sup>[Cryptography Extension Specification](https://github.com/riscv/riscv-crypto/releases/download/v1.0.1-scalar/riscv-crypto-spec-scalar-v1.0.1.pdf)
 
 ## Test Frameworks
 

--- a/content/languages/riscv/index.md
+++ b/content/languages/riscv/index.md
@@ -29,10 +29,10 @@ Codewars uses [QEMU user mode emulation](https://www.qemu.org/docs/master/user/m
     - `Zks` - ShangMi
 
 The most recent version of the specification for each can be downloaded below (as of 26 Dec 2023):
-- <sup>*</sup><a href="https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf" >RISC-V Unprivileged Specification</a>
-- <sup>†</sup>[Vector Extension Specification](https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf)
-- <sup>‡</sup>[Bit-Manipulation Extension Specification](https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0.pdf)
-- <sup>§</sup>[Cryptography Extension Specification](https://github.com/riscv/riscv-crypto/releases/download/v1.0.1-scalar/riscv-crypto-spec-scalar-v1.0.1.pdf)
+- <sup>*</sup><a href="https://github.com/riscv/riscv-isa-manual/releases/download/riscv-isa-release-056b6ff-2023-10-02/unpriv-isa-asciidoc.pdf" download rel="external" type="application/pdf">RISC-V Unprivileged Specification</a>
+- <sup>†</sup><a href="https://github.com/riscv/riscv-v-spec/releases/download/v1.0/riscv-v-spec-1.0.pdf" download rel="external" type="application/pdf">Vector Extension Specification</a>
+- <sup>‡</sup><a href="https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0.pdf" download rel="external" type="application/pdf">Bit-Manipulation Extension Specification</a>
+- <sup>§</sup><a href="https://github.com/riscv/riscv-crypto/releases/download/v1.0.1-scalar/riscv-crypto-spec-scalar-v1.0.1.pdf" download rel="external" type="application/pdf">Cryptography Extension Specification</a>
 
 ## Test Frameworks
 

--- a/content/languages/riscv/index.md
+++ b/content/languages/riscv/index.md
@@ -10,7 +10,9 @@ Beta
 
 ## Version
 
-RV64GCV_Zba_Zbb_Zbc_Zbs_Zbkx_Zk_Zks
+QEMU Toolchain: QEMU 7.1, GCC 11.3.0, Binutils 2.38
+
+ISA String: RV64GCV_Zba_Zbb_Zbc_Zbs_Zbkx_Zk_Zks
 
 Codewars uses [QEMU user mode emulation](https://www.qemu.org/docs/master/user/main.html) to support RISC-V content. Codewars is configured to use the following extensions for RISC-V:
 - `G` - General-Purpose*


### PR DESCRIPTION
Simple edit to reflect the extra extensions supported in codewars/riscv#7. Also adds links to specifications since some extensions are not included in the RISC-V Spec.
Still not completely happy with line 13, I feel like it's not visually appealing but the ISA string the closest there is to a version number. Maybe listing the QEMU version? Not sure.
As I will comment in codewars/riscv#7 as well, Zbkx is not necessary as it's in both Zk and Zks shorthands.