### PR TITLE
Update Haskell to GHC 9.2.5

### DIFF
--- a/content/languages/haskell/index.md
+++ b/content/languages/haskell/index.md
@@ -8,7 +8,7 @@ tags: [haskell]
 
 ## Versions
 
-- GHC 8.8.4 ([LTS Haskell 16.25](https://www.stackage.org/lts-16.25))
+- GHC 9.2.5 ([LTS Haskell 20.10](https://www.stackage.org/lts-20.10))
 
 ## Test Frameworks
 
@@ -18,41 +18,44 @@ tags: [haskell]
 
 12 seconds
 
+## Container image
+
+[Haskell container image at Github](https://github.com/codewars/haskell)
+
 ## Packages
 
-### GHC 8.8.4
+### GHC 9.2.5
 
-```yaml
-# From package.yaml
-# See https://www.stackage.org/lts-16.25 for versions
-dependencies:
-- base >= 4.7 && < 5
-- attoparsec
-- haskell-src-exts
-- hspec
-- hspec-attoparsec
-- hspec-codewars # https://github.com/codewars/hspec-codewars
-- hspec-contrib
-- hspec-formatters-codewars # https://github.com/codewars/hspec-formatters-codewars
-- hspec-megaparsec
-- HUnit-approx
-- lens
-- megaparsec
-- mtl
-- parsec
-- persistent
-- persistent-sqlite
-- persistent-template
-- QuickCheck
-- random
-- regex-pcre
-- regex-posix
-- regex-tdfa
-- split
-- text
-- transformers
-- vector
-```
+From [package.yaml](https://github.com/codewars/haskell/blob/main/workspace/package.yaml)
+
+| package | version |
+| --- | --- |
+| base | 4.16.4.0 |
+| attoparsec | 0.14.4 |
+| haskell-src-exts | 1.23.1 |
+| hspec | 2.9.7 |
+| hspec-attoparsec | 0.1.0.2 |
+| hspec-codewars | 0.1.0 |
+| hspec-contrib | 0.5.2 |
+| hspec-formatters-codewars | 0.3.0 |
+| hspec-megaparsec | 2.2.0 |
+| HUnit-approx | 1.1.1.1 |
+| lens | 5.1.1 |
+| megaparsec | 9.2.2 |
+| mtl | 2.2.2 |
+| parsec | 3.1.15.0 |
+| persistent | 2.13.3.5 |
+| persistent-sqlite | 2.13.1.1 |
+| persistent-template | 2.12.0.0 |
+| random | 1.2.1.1 |
+| regex-pcre | 0.95.0.0 |
+| regex-posix | 0.96.0.1 |
+| regex-tdfa | 1.3.2 |
+| split | 0.2.3.5 |
+| text | 1.2.5.0 |
+| transformers | 0.5.6.2 |
+| vector | 0.12.3.1 |
+
 
 ## Services
 


### PR DESCRIPTION
* update to GHC 9.2.5, updating stackage link to LTS 20.10
* add link to container repository
* add version table to packages
