### PR TITLE
Adjusted link to point to wiki

### DIFF
--- a/content/authoring/translation.md
+++ b/content/authoring/translation.md
@@ -5,7 +5,7 @@ tags: [authoring]
 
 _TBD: improve this stub_
 
-New translators may refer to the [tutorial(TODO)](/authoring/translation/).
+New translators may refer to the [tutorial(TODO)](https://github.com/Codewars/codewars.com/wiki/Tutorial:-How-to-translate-a-kata).
 
 Some [languages](/languages/) also have a page dedicated to authoring kata, with code examples and best practices.
 
@@ -30,6 +30,3 @@ When you publish your translation the original kata sensei will be automatically
 
 Tip: marking that comment as a `suggestion` will also help your translation from being accidentally overlooked.
 -->
-
-[sequential-code-blocks]: /references/markdown/extensions/#sequential-code-blocks
-[conditional-rendering]: /references/markdown/extensions/#conditional-rendering


### PR DESCRIPTION
The link on translation currently points to itself (and it doesn't have a lot of into), it confused me a lot when I wanted to try translations

The github wiki page is brilliant, I think it's a good idea to point there until the website has a better translation doc