### PR TITLE
addition to the "Troubleshooting your solution" page

### DIFF
--- a/content/training/troubleshooting.mdx
+++ b/content/training/troubleshooting.mdx
@@ -202,7 +202,9 @@ UndefinedBehaviorSanitizer can not provide additional info.
 ==1==ABORTING
 ```
 
-On Codewars, this error was usually seen when a solution attempted to dereference a past-the-end iterator, usually returned by `end( )` or by some function which signals some negative outcome by returning `end` iterator (for example, `std::find(myvec.begin(), myvec.end(), someValue)` will return `myvec.end()` if value is not found).
+There are some common causes for this problem:
+- attempt to dereference a past-the-end iterator, usually returned by `end( )` or by some function which signals some negative outcome by returning `end` iterator (for example, `std::find(myvec.begin(), myvec.end(), someValue)` will return `myvec.end()` if value is not found).
+- division by zero
 
 ### Exit code 137
 


### PR DESCRIPTION
from my experience, `ERROR: UndefinedBehaviorSanitizer: SEGV on unknown address 0x000000000000` can also happen when an attempt to divide by zero is made, so I added it as a possible cause of this error.